### PR TITLE
Restart error 129

### DIFF
--- a/trunk/SOURCE/netcdf_interface_mod.f90
+++ b/trunk/SOURCE/netcdf_interface_mod.f90
@@ -2483,7 +2483,7 @@
                               '&but this file cannot be extended due to' //  &
                               ' variable mismatch.' //                       &
                               '&New file is created instead.'
-f             CALL message( 'define_netcdf_header', 'PA0249', 0, 1, 0, 6, 0 )
+             CALL message( 'define_netcdf_header', 'PA0249', 0, 1, 0, 6, 0 )
              extend = .FALSE.
              RETURN
           ENDIF


### PR DESCRIPTION
I noticed that somewhere along the line we broke the restart capability. I've marked the error in netcdf_interface_mod.f90. I went back to @vanroekel 's old "palm_les_updates" version and verified that restart worked there. It did run successfully, but with a different error message:
    errors in local file ENVPAR
    some variables for steering may not be properly set
Do any of you know of a version of the code where you had a successful restart? Or do you have ideas about what the source of the issue is?
Thanks!