### PR TITLE
Error if 2-d data_output variables are included without section slice

### DIFF
--- a/trunk/SOURCE/check_parameters.f90
+++ b/trunk/SOURCE/check_parameters.f90
@@ -3318,15 +3318,15 @@
 
 !--       Make sure that section_nn is defined
           IF ( (data_output(i)(ilen-2:ilen) == '_xy') .AND. ( (section_xy(i) == -9999) ) ) THEN
-             message_string = 'to output _xy variables, section_xy must be defined'
+             message_string = 'to output _xy variables, the depth of at least one xy_section must be specified via the namelist parameter section_xy'
              CALL message( 'check_parameters', 'PA0561', 1, 2, 0, 6, 0 )
           ENDIF
           IF ( (data_output(i)(ilen-2:ilen) == '_xz') .AND. ( (section_xz(i) == -9999) ) ) THEN
-             message_string = 'to output _xz variables, section_xz must be defined'
+             message_string = 'to output _xz variables, the depth of at least one xz_section must be specified via the namelist parameter section_xz'
              CALL message( 'check_parameters', 'PA0561', 1, 2, 0, 6, 0 )
           ENDIF
           IF ( (data_output(i)(ilen-2:ilen) == '_yz') .AND. ( (section_yz(i) == -9999) ) ) THEN
-             message_string = 'to output _yz variables, section_yz must be defined'
+             message_string = 'to output _yz variables, the depth of at least one yz_section must be specified via the namelist parameter section_yz'
              CALL message( 'check_parameters', 'PA0561', 1, 2, 0, 6, 0 )
           ENDIF
 


### PR DESCRIPTION
This creates a needed check on profile variables. If 2-d data_output are included without a section slice location specified and the simulation continues, the simulation cannot be restarted.