### PR TITLE
Update namelists to use default advection scheme (ws-scheme)

### DIFF
--- a/diurnal_oceanml_p3d
+++ b/diurnal_oceanml_p3d
@@ -8,11 +8,8 @@
         idealized_diurnal = .F.,
 
         initializing_actions='read_restart_data'
- 
+
         latitude = 55.6,
-           
-        momentum_advec = 'pw-scheme',
-        scalar_advec = 'pw-scheme', 
 
         ug_surface =0.0, vg_surface = 0.0,
         pt_surface                 = 293.0,
@@ -24,14 +21,14 @@
         use_top_fluxes= .T.,
         use_surface_fluxes = .F.,
         constant_flux_layer= .F.,
-        
+
         top_momentumflux_u = 0.0,
         top_momentumflux_v = 0.0,
-        
+
         top_heatflux = 1.78e-5,
         top_salinityflux = 0.0,
 
-        bc_uv_b = 'neumann', bc_uv_t = 'neumann', 
+        bc_uv_b = 'neumann', bc_uv_t = 'neumann',
         bc_pt_b = 'neumann', bc_pt_t = 'neumann',
         bc_p_b  = 'neumann', bc_p_t  = 'neumann',
         bc_s_b  = 'initial_gradient', bc_s_t  = 'neumann',
@@ -49,11 +46,11 @@
         dt_data_output_av = 60.,
         termination_time_needed = 120.,
 
-        data_output = 'e', 'pt', 'sa', 'u', 'v', 'w', 'rho_ocean', 'alpha_T', 
+        data_output = 'e', 'pt', 'sa', 'u', 'v', 'w', 'rho_ocean', 'alpha_T',
 
-        data_output_pr = 'e','e*', '#pt', '#sa', 'p', 'hyp', 'km', 'kh', 'l', 
+        data_output_pr = 'e','e*', '#pt', '#sa', 'p', 'hyp', 'km', 'kh', 'l',
               '#u','#v','w','prho','w"u"','w*u*','w"v"','w*v*','w"pt"','w*pt*',
               'w"sa"','w*sa*','w*e*','u*2','v*2','w*2','pt*2','w*3','Sw',
               'w*2pt*','w*pt*2','w*u*u*:dz','w*p*:dz','rho_ocean','alpha_T', /
-       
+
 

--- a/diurnal_w_linear_EOS_p3d
+++ b/diurnal_w_linear_EOS_p3d
@@ -11,18 +11,15 @@
         rho_ref = 1000.0
         fixed_alpha = .TRUE.
         alpha_const = 2.0E-4
-        beta_const = 8.0E-4 
+        beta_const = 8.0E-4
         pt_ref = 15.0
         sa_ref = 35.0
 
         loop_optimization = 'vector',
 
         initializing_actions = 'set_constant_profiles',
- 
+
         latitude = 55.6,
-           
-        momentum_advec = 'pw-scheme',
-        scalar_advec = 'pw-scheme', 
 
         ug_surface =0.0, vg_surface = 0.0,
         pt_surface                 = 276.74,
@@ -35,14 +32,14 @@
         use_top_fluxes= .T.,
         use_surface_fluxes = .F.,
         constant_flux_layer= .F.,
-        
+
         top_momentumflux_u = 0.0,
         top_momentumflux_v = 0.0,
-        
+
         top_heatflux = 0.,
         top_salinityflux = 0.0,
 
-        bc_uv_b = 'neumann', bc_uv_t = 'neumann', 
+        bc_uv_b = 'neumann', bc_uv_t = 'neumann',
         bc_pt_b = 'neumann', bc_pt_t = 'neumann',
         bc_p_b  = 'neumann', bc_p_t  = 'neumann',
         bc_s_b  = 'initial_gradient', bc_s_t  = 'neumann',
@@ -62,11 +59,11 @@
 
         netcdf_data_format = 3,
 
-        data_output = 'shf*_xy', 'e', 'pt', 'sa', 'u', 'v', 'w', 'rho_ocean', 'alpha_T', 'solar3d', 
+        data_output = 'shf*_xy', 'e', 'pt', 'sa', 'u', 'v', 'w', 'rho_ocean', 'alpha_T', 'solar3d',
 
-        data_output_pr = 'e','e*', '#pt', '#sa', 'p', 'hyp', 'km', 'kh', 'l', 
+        data_output_pr = 'e','e*', '#pt', '#sa', 'p', 'hyp', 'km', 'kh', 'l',
               '#u','#v','w','prho','w"u"','w*u*','w"v"','w*v*','w"pt"','w*pt*',
               'w"sa"','w*sa*','w*e*','u*2','v*2','w*2','pt*2','w*3','Sw',
               'w*2pt*','w*pt*2','w*u*u*:dz','w*p*:dz','rho_ocean','alpha_T', 'solar3d', /
-       
+
 

--- a/restart_oceanml_p3d
+++ b/restart_oceanml_p3d
@@ -9,9 +9,6 @@
        initializing_actions = 'read_restart_data',
 
         latitude = 55.6,
-           
-        momentum_advec = 'pw-scheme',
-        scalar_advec = 'pw-scheme', 
 
         ug_surface =0.0, vg_surface = 0.0,
         pt_surface                 = 300.0,
@@ -19,14 +16,14 @@
         use_top_fluxes= .T.,
         use_surface_fluxes = .F.,
         constant_flux_layer= .F.,
-        
+
         top_momentumflux_u = -0.0001,
         top_momentumflux_v = 0.0,
-        
+
         top_heatflux = 0.0,
         top_salinityflux = 0.0,
 
-        bc_uv_b = 'neumann', bc_uv_t = 'neumann', 
+        bc_uv_b = 'neumann', bc_uv_t = 'neumann',
         bc_pt_b = 'neumann', bc_pt_t = 'neumann',
         bc_p_b  = 'neumann', bc_p_t  = 'neumann',
         bc_s_b  = 'initial_gradient', bc_s_t  = 'neumann',
@@ -41,7 +38,7 @@
         dt_run_control = 0.0,
         restart_time = 100.0
         data_output_pr = 'e','e*', '#pt',  /
-       
+
 %write_binary true restart
       #
       PARIN in:job      d3#   $base_data/$fname/INPUT _p3d

--- a/scaling_test_oceanml_p3d
+++ b/scaling_test_oceanml_p3d
@@ -8,11 +8,8 @@
         idealized_diurnal = .F.,
 
         initializing_actions = 'set_constant_profiles',
- 
+
         latitude = 55.6,
-           
-        momentum_advec = 'pw-scheme',
-        scalar_advec = 'pw-scheme', 
 
         ug_surface =0.0, vg_surface = 0.0,
         pt_surface                 = 293.0,
@@ -24,14 +21,14 @@
         use_top_fluxes= .T.,
         use_surface_fluxes = .F.,
         constant_flux_layer= .F.,
-        
+
         top_momentumflux_u = 0.0,
         top_momentumflux_v = 0.0,
-        
+
         top_heatflux = 1.78e-5,
         top_salinityflux = 0.0,
 
-        bc_uv_b = 'neumann', bc_uv_t = 'neumann', 
+        bc_uv_b = 'neumann', bc_uv_t = 'neumann',
         bc_pt_b = 'neumann', bc_pt_t = 'neumann',
         bc_p_b  = 'neumann', bc_p_t  = 'neumann',
         bc_s_b  = 'initial_gradient', bc_s_t  = 'neumann',
@@ -50,11 +47,11 @@
 
 	netcdf_data_format = 3,
 
-        data_output = 'shf*_xy', 'e', 'pt', 'sa', 'u', 'v', 'w', 'rho_ocean', 'alpha_T', 
+        data_output = 'shf*_xy', 'e', 'pt', 'sa', 'u', 'v', 'w', 'rho_ocean', 'alpha_T',
 
-        data_output_pr = 'e','e*', '#pt', '#sa', 'p', 'hyp', 'km', 'kh', 'l', 
+        data_output_pr = 'e','e*', '#pt', '#sa', 'p', 'hyp', 'km', 'kh', 'l',
               '#u','#v','w','prho','w"u"','w*u*','w"v"','w*v*','w"pt"','w*pt*',
               'w"sa"','w*sa*','w*e*','u*2','v*2','w*2','pt*2','w*3','Sw',
               'w*2pt*','w*pt*2','w*u*u*:dz','w*p*:dz','rho_ocean','alpha_T', /
-       
+
 

--- a/test_coupled_o_p3d
+++ b/test_coupled_o_p3d
@@ -11,9 +11,6 @@
 
         latitude = 55.6,
 
-        momentum_advec = 'pw-scheme',
-        scalar_advec = 'pw-scheme',
-
         ug_surface =0.0, vg_surface = 0.0,
         pt_surface                 = 293.0,
         pt_vertical_gradient       = 1.0,

--- a/test_coupled_p3d
+++ b/test_coupled_p3d
@@ -13,9 +13,6 @@
 
         humidity = .T.,
 
-        momentum_advec = 'pw-scheme',
-        scalar_advec = 'pw-scheme',
-
         ug_surface =0.0, vg_surface = 0.0,
         pt_surface                 = 293.0,
         pt_vertical_gradient       = 3.0,

--- a/test_oceanml_p3d
+++ b/test_oceanml_p3d
@@ -11,9 +11,6 @@
 
         latitude = 55.6,
 
-        momentum_advec = 'pw-scheme',
-        scalar_advec = 'pw-scheme',
-
         ug_surface =0.0, vg_surface = 0.0,
         pt_surface                 = 293.0,
         pt_vertical_gradient       = 1.0,


### PR DESCRIPTION
This PR removes the following lines in all the namelists (*_p3d), so that the default advection scheme `ws-scheme` will be used.

`momentum_advec = 'pw-scheme',`
`scalar_advec = 'pw-scheme',`