### PR TITLE
More sloped ocean options

### DIFF
--- a/trunk/SOURCE/init_slope.f90
+++ b/trunk/SOURCE/init_slope.f90
@@ -81,7 +81,8 @@
         ONLY:  initializing_actions, ocean,                                    &
                alpha_surface, sin_alpha_surface, slope_offset,                 &
                pt_surface, pt_vertical_gradient, pt_slope_offset,              &
-               sa_surface, sa_vertical_gradient, sa_slope_offset
+               sa_surface, sa_vertical_gradient, sa_slope_offset,              &
+               slope_parallel_gradients
 
     USE eqn_state_seawater_mod,                                                &
         ONLY:  eqn_state_seawater, eqn_state_seawater_func
@@ -124,7 +125,7 @@
 
     DO  i = nxlg, nxrg
        DO  k = nzb, nzt+1
-          IF ( slope_offset ) THEN
+          IF ( .NOT. slope_parallel_gradients ) THEN
 !
 !--          Compute height of grid-point relative to lower left corner of
 !--          the total domain.

--- a/trunk/SOURCE/modules.f90
+++ b/trunk/SOURCE/modules.f90
@@ -1397,7 +1397,8 @@
     LOGICAL ::  run_coupled = .TRUE.                             !< internal switch telling PALM to run in coupled mode (i.e. to exchange surface data) in case of atmosphere-ocean coupling
     LOGICAL ::  scalar_rayleigh_damping = .TRUE.                 !< namelist parameter
     LOGICAL ::  sloping_surface = .FALSE.                        !< use sloped surface? (namelist parameter alpha_surface)
-    LOGICAL ::  slope_offset = .FALSE.                           !< default slope conditions are slope_parallel, when TRUE use horizontal isopynals with slope offset
+    LOGICAL ::  slope_offset = .FALSE.                           !< when true, offset scalar properties for periodic flow in x-direction according to initial scalar gradients 
+    LOGICAL ::  slope_parallel_gradients = .TRUE.                !< default slope conditions are slope_parallel, when FALSE use horizontal isopynals
     LOGICAL ::  spinup = .FALSE.                                 !< perform model spinup without atmosphere code?
     LOGICAL ::  stokes_force = .FALSE.                           !< switch for use of Stokes forces
     LOGICAL ::  stop_dt = .FALSE.                                !< internal switch to stop the time stepping

--- a/trunk/SOURCE/parin.f90
+++ b/trunk/SOURCE/parin.f90
@@ -552,8 +552,8 @@
              reference_state, residual_limit,                                  &
              roughness_length, sa_surface,                                     &
              sa_vertical_gradient, sa_vertical_gradient_level, scalar_advec,   &
-             scalar_rayleigh_damping, slope_offset, sigma_bulk,                &
-             spinup_time, spinup_pt_amplitude, spinup_pt_mean,                 &
+             scalar_rayleigh_damping, slope_offset, slope_parallel_gradients,  &
+             sigma_bulk, spinup_time, spinup_pt_amplitude, spinup_pt_mean,     &
              statistic_regions, stokes_force, stokes_drift_method,             &
              subs_vertical_gradient,                                           &
              subs_vertical_gradient_level, surface_heatflux, surface_pressure, &
@@ -634,8 +634,8 @@
              reference_state, residual_limit,                                  &
              roughness_length, sa_surface,                                     &
              sa_vertical_gradient, sa_vertical_gradient_level, scalar_advec,   &
-             scalar_rayleigh_damping, slope_offset, sigma_bulk,                &
-             spinup_time, spinup_pt_amplitude, spinup_pt_mean,                 &
+             scalar_rayleigh_damping, slope_offset, slope_parallel_gradients,  &
+             sigma_bulk, spinup_time, spinup_pt_amplitude, spinup_pt_mean,     &
              statistic_regions, stokes_force, stokes_drift_method,             &
              subs_vertical_gradient,                                           &
              subs_vertical_gradient_level, surface_heatflux, surface_pressure, &

--- a/trunk/SOURCE/read_restart_data_mod.f90
+++ b/trunk/SOURCE/read_restart_data_mod.f90
@@ -601,6 +601,8 @@
                 READ ( 13 )  scalar_advec
              CASE ( 'slope_offset' )
                 READ ( 13 )  slope_offset
+             CASE ( 'slope_parallel_gradients' )
+                READ ( 13 )  slope_parallel_gradients
              CASE ( 'simulated_time' )
                 READ ( 13 )  simulated_time
              CASE ( 'spectrum_x' )

--- a/trunk/SOURCE/write_restart_data_mod.f90
+++ b/trunk/SOURCE/write_restart_data_mod.f90
@@ -669,6 +669,9 @@
        CALL wrd_write_string( 'slope_offset' ) 
        WRITE ( 14 )  slope_offset
 
+       CALL wrd_write_string( 'slope_parallel_gradients' ) 
+       WRITE ( 14 )  slope_parallel_gradients
+
        CALL wrd_write_string( 'simulated_time' ) 
        WRITE ( 14 )  simulated_time
 


### PR DESCRIPTION
This PR decouples namelist options pertaining to sloped ocean cases:
previously, `slope_offset=true` set initial isopycnals to be horizontal and implemented periodic offset according to initial scalar gradients
now, 'slope_offset = true' sets periodic offset and a new parameter `slope_parallel_gradients` determines whether initial isopycnals are parallel to the slope.
By default, `slope_offset = false` and `slope_parallel_gradients = true`