### PR TITLE
Fix flux units of output data

### DIFF
--- a/trunk/SOURCE/init_3d_model.f90
+++ b/trunk/SOURCE/init_3d_model.f90
@@ -991,7 +991,7 @@
             heatflux_input_conversion(k)      = rho_ref_zw(k)
             waterflux_input_conversion(k)     = rho_ref_zw(k)
             momentumflux_input_conversion(k)  = rho_ref_zw(k)
-            scalarflux_input_conversion(k)    = 1.0_wp
+            scalarflux_input_conversion(k)    = rho_ref_zw(k)
             salinityflux_input_conversion(k)  = rho_ref_zw(k)
         ELSEIF ( TRIM( flux_input_mode ) == 'dynamic' ) THEN
             heatflux_input_conversion(k)      = 1.0_wp / cp
@@ -1007,7 +1007,7 @@
             heatflux_output_conversion(k)     = drho_ref_zw(k)
             waterflux_output_conversion(k)    = drho_ref_zw(k)
             momentumflux_output_conversion(k) = drho_ref_zw(k)
-            scalarflux_output_conversion(k)   = 1.0_wp
+            scalarflux_output_conversion(k)   = drho_ref_zw(k)
             salinityflux_output_conversion(k) = drho_ref_zw(k)
         ELSEIF ( TRIM( flux_output_mode ) == 'dynamic' ) THEN
             heatflux_output_conversion(k)     = cp


### PR DESCRIPTION
Contains two changes to data output method:
* we modify units of resolved fluxes so they are consistent with user-defined input and output units. Both resolved and SGS fluxes are computed as `rho_0 * w'X' * output_conversion_factor`.
* scalarflux_output_conversion also needs to take units `1/rho_0` as any flux input to `diffusion_s` is assumed to take the form `rho_0 * w'X`
* For MOST method 'mcphee', we output T,S at the top boundary in profiles. This requires excluding the nzt point from the post-facto calculation of resolved w'T' and w'S'