### PR TITLE
Add switch for horizontal velocity restoring

### DIFF
--- a/trunk/SOURCE/init_3d_model.f90
+++ b/trunk/SOURCE/init_3d_model.f90
@@ -654,7 +654,8 @@
               ngp_3d_inner_tmp(0:statistic_regions),                           &
               sums_divnew_l(0:statistic_regions),                              &
               sums_divold_l(0:statistic_regions) )
-    ALLOCATE( dp_smooth_factor(nzb:nzt), rdf(nzb+1:nzt), rdf_sc(nzb+1:nzt) )
+    ALLOCATE( dp_smooth_factor(nzb:nzt),                                       &
+              rdf(nzb+1:nzt), rdf_uv(nzb+1:nzt), rdf_sc(nzb+1:nzt) )
     ALLOCATE( ngp_2dh_outer(nzb:nzt+1,0:statistic_regions),                    &
               ngp_2dh_outer_l(nzb:nzt+1,0:statistic_regions),                  &
               ngp_2dh_s_inner(nzb:nzt+1,0:statistic_regions),                  &
@@ -2607,6 +2608,7 @@
 !
 !-- Initialize Rayleigh damping factors
     rdf    = 0.0_wp
+    rdf_uv = 0.0_wp
     rdf_sc = 0.0_wp
     IF ( rayleigh_damping_factor /= 0.0_wp )  THEN
        IF (  .NOT.  ocean )  THEN
@@ -2630,6 +2632,7 @@
        ENDIF
     ENDIF
     IF ( scalar_rayleigh_damping )  rdf_sc = rdf
+    IF ( horizontal_rayleigh_damping )  rdf_uv = rdf
 
 !
 !-- Initialize the starting level and the vertical smoothing factor used for 

--- a/trunk/SOURCE/modules.f90
+++ b/trunk/SOURCE/modules.f90
@@ -674,6 +674,7 @@
                                                                    !< (or total water content with active cloud physics)
     REAL(wp), DIMENSION(:), ALLOCATABLE ::  rdf                    !< rayleigh damping factor for velocity components
     REAL(wp), DIMENSION(:), ALLOCATABLE ::  rdf_sc                 !< rayleigh damping factor for scalar quantities
+    REAL(wp), DIMENSION(:), ALLOCATABLE ::  rdf_uv                 !< rayleigh damping factor for scalar quantities
     REAL(wp), DIMENSION(:), ALLOCATABLE ::  ref_state              !< reference state of potential temperature
                                                                    !< (and density in case of ocean simulation)
     REAL(wp), DIMENSION(:), ALLOCATABLE ::  s_init                 !< initial profile of passive scalar concentration
@@ -1390,6 +1391,7 @@
     LOGICAL ::  ocean = .FALSE.                                  !< namelist parameter
     LOGICAL ::  linear_eqnOfState = .FALSE.                      !< namelist parmaeter for linear equation of state in ocean
     LOGICAL ::  fixed_alpha = .TRUE.                             !< use fixed thermal and haline expansion coefficients
+    LOGICAL ::  horizontal_rayleigh_damping = .FALSE.            !< namelist parameter
     LOGICAL ::  idealized_diurnal = .FALSE.                      !< flag for diurnal cycle
     LOGICAL ::  outflow_l = .FALSE.                              !< left domain boundary has non-cyclic outflow?
     LOGICAL ::  outflow_n = .FALSE.                              !< north domain boundary has non-cyclic outflow?

--- a/trunk/SOURCE/prognostic_equations.f90
+++ b/trunk/SOURCE/prognostic_equations.f90
@@ -284,7 +284,8 @@
                flux_s_qc, flux_s_qr, flux_s_s, flux_s_sa, flux_l_e, flux_l_nc, &
                flux_l_nr, flux_l_pt, flux_l_q, flux_l_qc, flux_l_qr, flux_l_s, &
                flux_l_sa, nc, nc_p, nr, nr_p, pt, ptdf_x, ptdf_y, pt_init,     &
-               pt_p, prho, q, q_init, q_p, qc, qc_p, qr, qr_p, rdf, rdf_sc,    &
+               pt_p, prho, q, q_init, q_p, qc, qc_p, qr, qr_p,                 &
+               rdf, rdf_uv, rdf_sc,                                            &
                ref_state, rho_ocean, s,  s_init, s_p, sa, sa_init, sa_p, tend, &
                te_m, tnc_m,  tnr_m, tpt_m, tq_m, tqc_m, tqr_m, ts_m, tsa_m,    &
                tu_m, tv_m, tw_m, u, ug, u_init, u_p, v, vg, vpt, v_init, v_p,  &
@@ -655,7 +656,7 @@
                 u_p(k,j,i) = u(k,j,i) + ( dt_3d *                               &
                                             ( tsc(2) * tend(k,j,i) +            &
                                               tsc(3) * tu_m(k,j,i) )            &
-                                            - tsc(5) * rdf(k)                   &
+                                            - tsc(5) * rdf_uv(k)                &
                                                      * ( u(k,j,i) - u_init(k) ) &
                                         ) * MERGE( 1.0_wp, 0.0_wp,              &
                                                  BTEST( wall_flags_0(k,j,i), 1 )&
@@ -746,7 +747,7 @@
                 v_p(k,j,i) = v(k,j,i) + ( dt_3d *                              &
                                             ( tsc(2) * tend(k,j,i) +           &
                                               tsc(3) * tv_m(k,j,i) )           &
-                                            - tsc(5) * rdf(k)                  &
+                                            - tsc(5) * rdf_uv(k)               &
                                                      * ( v(k,j,i) - v_init(k) )&
                                         ) * MERGE( 1.0_wp, 0.0_wp,             &
                                                    BTEST( wall_flags_0(k,j,i), 2 )&


### PR DESCRIPTION
This PR adds a new logical namelist parameter which designates whether the rayleigh damping factor (depth-dependent) that is prescribed will be applied to horizontal velocity components. If this factor is nonzero, it is automatically applied to vertical velocity component. The implementation follows that of the scalar restoring option added by PR #39.