### PR TITLE
Add ability to set u and v dirichlet values at top and bottom

### DIFF
--- a/trunk/SOURCE/boundary_conds.f90
+++ b/trunk/SOURCE/boundary_conds.f90
@@ -202,7 +202,7 @@
                nest_bound_l, nest_bound_n, nest_bound_r, nest_bound_s, nudging,&
                ocean, outflow_l, outflow_n, outflow_r, outflow_s,              &
                passive_scalar, pt_surface_rate_change, rans_mode, rans_tke_e,  &
-               tsc, use_cmax
+               tsc, use_cmax, u_top, u_bott, v_top, v_bott
 
     USE grid_variables,                                                        &
         ONLY:  ddx, ddy, dx, dy
@@ -235,8 +235,15 @@
 
 
 !
-!-- Bottom boundary 
-    IF ( ibc_uv_b == 1 )  THEN
+!-- Bottom boundary
+    IF ( ibc_uv_b == 0 ) THEN
+       IF ( u_bott /= 9999999.9_wp ) THEN
+          u_p(nzb,:,:) = u_bott
+       ENDIF
+       IF ( v_bott /= 9999999.9_wp ) THEN
+          v_p(nzb,:,:) = v_bott
+       ENDIF
+    ELSEIF ( ibc_uv_b == 1 )  THEN
        u_p(nzb,:,:) = u_p(nzb+1,:,:)
        v_p(nzb,:,:) = v_p(nzb+1,:,:)
     ENDIF
@@ -260,8 +267,16 @@
 !
 !-- Top boundary. A nested domain ( ibc_uv_t = 3 ) does not require settings.
     IF ( ibc_uv_t == 0 )  THEN
-        u_p(nzt+1,:,:) = u_init(nzt+1)
-        v_p(nzt+1,:,:) = v_init(nzt+1)
+       IF ( u_top /= 9999999.9_wp ) THEN
+          u_p(nzt+1,:,:) = u_top
+       ELSE
+          u_p(nzt+1,:,:) = u_init(nzt+1)
+       ENDIF
+       IF ( v_top /= 9999999.9_wp ) THEN
+          v_p(nzt+1,:,:) = v_top
+       ELSE
+          v_p(nzt+1,:,:) = v_init(nzt+1)
+       ENDIF
     ELSEIF ( ibc_uv_t == 1 )  THEN
         u_p(nzt+1,:,:) = u_p(nzt,:,:)
         v_p(nzt+1,:,:) = v_p(nzt,:,:)

--- a/trunk/SOURCE/boundary_conds.f90
+++ b/trunk/SOURCE/boundary_conds.f90
@@ -239,9 +239,13 @@
     IF ( ibc_uv_b == 0 ) THEN
        IF ( u_bott /= 9999999.9_wp ) THEN
           u_p(nzb,:,:) = u_bott
+       ELSE
+          u_p(nzb,:,:) = u_init(nzb)
        ENDIF
        IF ( v_bott /= 9999999.9_wp ) THEN
           v_p(nzb,:,:) = v_bott
+       ELSE
+          v_p(nzb,:,:) = v_init(nzb)
        ENDIF
     ELSEIF ( ibc_uv_b == 1 )  THEN
        u_p(nzb,:,:) = u_p(nzb+1,:,:)

--- a/trunk/SOURCE/check_parameters.f90
+++ b/trunk/SOURCE/check_parameters.f90
@@ -1589,6 +1589,24 @@
             chem_species(lsp)%conc_pr_init = cs_surface(lsp)
          ENDDO
        ENDIF
+
+!
+!--    Check that geostrophic velocities are imposed only through a
+!--    horizontal pressure gradient OR through setting the appropriate
+!--    ug terms in the input file
+       DO i = 1, 10
+          IF (rayleigh_damping_geostrophic .AND. (ug_surface /= 0.0_wp            &
+               .OR. vg_surface /= 0.0_wp .OR. ug_vertical_gradient(i) /=0.0_wp    &
+               .OR. vg_vertical_gradient(i) /=0.0_wp)) THEN
+             WRITE( message_string, *) 'ERROR: Geostrophic velocities &
+                  are being set in both the pressure and coriolis terms. &
+                  Either set rayleigh_damping_geostrophic = .F. or set &
+                  ug_surface, vg_surface, ug_vertical_gradient, and &
+                  vg_vertical_gradient to 0. '
+             CALL message( 'check_parameters', 'PA0900', 1, 2, 0, 6, 0)
+          ENDIF
+       ENDDO
+
 !
 !--
 !--    If required, compute initial profile of the geostrophic wind
@@ -1652,23 +1670,6 @@
        IF ( ug_vertical_gradient_level(1) == -9999999.9_wp )  THEN
           ug_vertical_gradient_level(1) = 0.0_wp
        ENDIF
-
-! 
-!--    Check that geostrophic velocities are imposed only through a
-!--    horizontal pressure gradient OR through setting the appropriate
-!--    ug terms in the input file
-       DO i = 1, 11
-          IF (rayleigh_damping_geostrophic .AND. (ug_surface /= 0.0_wp            &
-               .OR. vg_surface /= 0.0_wp .OR. ug_vertical_gradient(i) /=0.0_wp    &
-               .OR. vg_vertical_gradient(i) /=0.0_wp)) THEN
-             WRITE( message_string, *) 'ERROR: Geostrophic velocities &
-                  are being set in both the pressure and coriolis terms. &
-                  Either set rayleigh_damping_geostrophic = .F. or set &
-                  ug_surface, vg_surface, ug_vertical_gradient, and &
-                  vg_vertical_gradient to 0. '
-             CALL message( 'check_parameters', 'PA0900', 1, 2, 0, 6, 0)
-          ENDIF
-       ENDDO
 
 !
 !--

--- a/trunk/SOURCE/check_parameters.f90
+++ b/trunk/SOURCE/check_parameters.f90
@@ -1088,7 +1088,14 @@
        IF ( cloud_droplets )  THEN
           WRITE( action, '(A)' )  'cloud_droplets = .TRUE.'
        ENDIF
-       IF ( TRIM(constant_flux_layer) == 'top'  .OR.                           &
+       IF ( u_bott /= 9999999.9_wp ) THEN
+          WRITE( action, '(A)' ) 'u_bott /= 9999999.9_wp'
+       ENDIF
+       IF( v_bott /= 9999999.9_wp ) THEN
+          WRITE( action, '(A)' ) 'v_bott /= 9999999.9_wp'
+       ENDIF
+       IF ( TRIM(constant_flux_layer) == 'none' .OR.                           &
+            TRIM(constant_flux_layer) == 'top'  .OR.                           &
             TRIM(constant_flux_layer) == 'bottom'    ) THEN
           WRITE( action, '(A,A)' )  'constant_flux_layer = ', TRIM(constant_flux_layer)
        ENDIF

--- a/trunk/SOURCE/modules.f90
+++ b/trunk/SOURCE/modules.f90
@@ -1398,7 +1398,7 @@
     LOGICAL ::  inflow_n = .FALSE.                               !< north domain boundary has non-cyclic inflow?
     LOGICAL ::  inflow_r = .FALSE.                               !< right domain boundary has non-cyclic inflow?
     LOGICAL ::  inflow_s = .FALSE.                               !< south domain boundary has non-cyclic inflow?
-    LOGICAL ::  initialize_to_geostrophic = .TRUE.               !< namelist parameter, damp to the geostrophic velocity
+    LOGICAL ::  initialize_to_geostrophic = .FALSE.              !< namelist parameter, damp to the geostrophic velocity
     LOGICAL ::  koff_constant_mcphee = .FALSE.                   !< namelist parameter
     LOGICAL ::  large_scale_forcing = .FALSE.                    !< namelist parameter
     LOGICAL ::  large_scale_subsidence = .FALSE.                 !< namelist parameter
@@ -1664,9 +1664,13 @@
     REAL(wp) ::  tunnel_width_x = 9999999.9_wp                 !< namelist parameter
     REAL(wp) ::  tunnel_width_y = 9999999.9_wp                 !< namelist parameter
     REAL(wp) ::  tunnel_wall_depth = 9999999.9_wp              !< namelist parameter
+    REAL(wp) ::  u_top = 9999999.9_wp                          !< namelist parameter
+    REAL(wp) ::  u_bott = 9999999.9_wp                         !< namelist parameter
     REAL(wp) ::  ug_surface = 0.0_wp                           !< namelist parameter
     REAL(wp) ::  u_bulk = 0.0_wp                               !< namelist parameter
     REAL(wp) ::  u_gtrans = 0.0_wp                             !< transformed wind component (galilei transformation)
+    REAL(wp) ::  v_top = 9999999.9_wp                          !< namelist parameter
+    REAL(wp) ::  v_bott = 9999999.9_wp                         !< namelist parameter
     REAL(wp) ::  vg_surface = 0.0_wp                           !< namelist parameter
     REAL(wp) ::  vpt_reference = 9999999.9_wp                  !< reference state of virtual potential temperature
     REAL(wp) ::  v_bulk = 0.0_wp                               !< namelist parameter

--- a/trunk/SOURCE/parin.f90
+++ b/trunk/SOURCE/parin.f90
@@ -571,7 +571,7 @@
              use_subsidence_tendencies, ug_surface, ug_vertical_gradient,      &
              ug_vertical_gradient_level, use_surface_fluxes, use_cmax,         &
              use_top_fluxes, use_ug_for_galilei_tr, use_upstream_for_tke,      &
-             uv_heights, u_bulk, u_profile,                                    &
+             uv_heights, u_bulk, u_profile, u_top, u_bott,                     &
              v0_stk, vg_surface, vg_vertical_gradient,                         &
              vg_vertical_gradient_level, v_bulk, v_profile, ventilation_effect,&
              wall_adjustment, wall_heatflux, wall_humidityflux,                &
@@ -660,7 +660,7 @@
              use_subsidence_tendencies, ug_surface, ug_vertical_gradient,      &
              ug_vertical_gradient_level, use_surface_fluxes, use_cmax,         &
              use_top_fluxes, use_ug_for_galilei_tr, use_upstream_for_tke,      &
-             uv_heights, u_bulk, u_profile,                                    &
+             uv_heights, u_bulk, u_profile, u_top, u_bott,                     &
              v0_stk,  vg_surface, vg_vertical_gradient,                        &
              vg_vertical_gradient_level, v_bulk, v_profile, ventilation_effect,&
              wall_adjustment, wall_heatflux, wall_humidityflux,                &

--- a/trunk/SOURCE/read_restart_data_mod.f90
+++ b/trunk/SOURCE/read_restart_data_mod.f90
@@ -713,6 +713,10 @@
                 READ ( 13 )  u_max
              CASE ( 'u_max_ijk' )
                 READ ( 13 )  u_max_ijk
+             CASE ( 'u_top' )
+                READ ( 13 ) u_top
+             CASE ( 'u_bott' )
+                READ ( 13 ) u_bott
              CASE ( 'ug' )
                 READ ( 13 )  ug
              CASE ( 'ug_surface' )
@@ -739,6 +743,10 @@
                 READ ( 13 )  v_max
              CASE ( 'v_max_ijk' )
                 READ ( 13 )  v_max_ijk
+             CASE ( 'v_top' )
+                READ ( 13 ) v_top
+             CASE ( 'v_bott' )
+                READ ( 13 ) v_bott
              CASE ( 'ventilation_effect' )
                 READ ( 13 )  ventilation_effect
              CASE ( 'vg' )

--- a/trunk/SOURCE/write_restart_data_mod.f90
+++ b/trunk/SOURCE/write_restart_data_mod.f90
@@ -828,6 +828,12 @@
 
        CALL wrd_write_string( 'u_max_ijk' ) 
        WRITE ( 14 )  u_max_ijk
+       
+       CALL wrd_write_string( 'u_top' )
+       WRITE ( 14 )  u_top
+
+       CALL wrd_write_string( 'u_bott' )
+       WRITE ( 14 )  u_bott
 
        CALL wrd_write_string( 'ug' ) 
        WRITE ( 14 )  ug
@@ -867,6 +873,12 @@
 
        CALL wrd_write_string( 'v_max_ijk' ) 
        WRITE ( 14 )  v_max_ijk
+
+       CALL wrd_write_string( 'v_top' )
+       WRITE ( 14 )  v_top
+
+       CALL wrd_write_string( 'v_bott' )
+       WRITE ( 14 )  v_bott
 
        CALL wrd_write_string( 'ventilation_effect' ) 
        WRITE ( 14 )  ventilation_effect


### PR DESCRIPTION
I've implemented this be able to set surface sea ice drift velocities to be used with the MOST approach already in place, but this can be used to set the u and v velocities at both the top and bottom boundaries, using the namelist parameters `u_top`, `u_bott`, `v_top`, and `v_bott`. If left unset or set to 9999999.9 it will not use these parameters to set the top and bottom boundary conditions, and it will revert to what was previous implemented in the code. The way this is set up you could have geostrophic velocities set by either `ug_surface` and `vg_surface` or through the pressure gradient, but still be able to set a different BC value. I imagined this would be the case if you had ice drift (or an ice shelf, i.e. `u_top` = `v_top` = 0.0) and geostrophic velocities/river inflow/etc...? so I wanted to keep this as an option, but I am open to implementing this in a different way if someone has a better idea or thinks there will be an issue here.