### PR TITLE
Remove stratification term from AMD closure

### DIFF
--- a/trunk/SOURCE/modules.f90
+++ b/trunk/SOURCE/modules.f90
@@ -1450,6 +1450,7 @@
     LOGICAL ::  spinup = .FALSE.                                 !< perform model spinup without atmosphere code?
     LOGICAL ::  stokes_force = .FALSE.                           !< switch for use of Stokes forces
     LOGICAL ::  stop_dt = .FALSE.                                !< internal switch to stop the time stepping
+    LOGICAL ::  stratification_affects_km = .FALSE.              !< namelist parameter for amd scheme
     LOGICAL ::  surface_flux_diags = .FALSE.                     !< namelist parameter
     LOGICAL ::  synchronous_exchange = .FALSE.                   !< namelist parameter
     LOGICAL ::  syn_turb_gen = .FALSE.                           !< flag for synthetic turbulence generator module

--- a/trunk/SOURCE/modules.f90
+++ b/trunk/SOURCE/modules.f90
@@ -1182,7 +1182,7 @@
     CHARACTER (LEN=20)   ::  coupling_mode_remote = 'uncoupled'           !< coupling mode of the remote process in case of coupled atmosphere-ocean runs
     CHARACTER (LEN=20)   ::  dissipation_1d = 'detering'                  !< namelist parameter
     CHARACTER (LEN=20)   ::  fft_method = 'temperton-algorithm'           !< namelist parameter
-    CHARACTER (LEN=20)   ::  gamma_mcphee = 'BL-integrated'               !< namelist parameter
+    CHARACTER (LEN=20)   ::  gamma_mcphee = 'depth-dependent'             !< namelist parameter
     CHARACTER (LEN=20)   ::  mixing_length_1d = 'blackadar'               !< namelist parameter
     CHARACTER (LEN=20)   ::  random_generator = 'random-parallel'         !< namelist parameter
     CHARACTER (LEN=20)   ::  reference_state = 'initial_profile'          !< namelist parameter
@@ -1487,7 +1487,7 @@
                                                                !< (galilei transformation) 
     REAL(wp) ::  advected_distance_y = 0.0_wp                  !< advected distance of model domain along y 
                                                                !< (galilei transformation)
-    REAL(wp) ::  alpha_surface = 0.0_wp                        !< namelist parameter
+    REAL(wp) ::  alpha_surface = 0.0_wp                        !< namelist parameter, slope in degrees
     REAL(wp) ::  alpha_const = 2.0E-4                          !< fixed alpha_T value
     REAL(wp) ::  atmos_ocean_sign = 1.0_wp                     !< vertical-grid conversion factor 
                                                                !< (=1.0 in atmosphere, =-1.0 in ocean)
@@ -1548,6 +1548,7 @@
     REAL(wp) ::  dt_do3d = 9999999.9_wp                        !< namelist parameter
     REAL(wp) ::  dt_dvrp = 9999999.9_wp                        !< namelist parameter
     REAL(wp) ::  dt_max = 20.0_wp                              !< namelist parameter
+    REAL(wp) ::  dt_min = 0.0020_wp                            !< namelist parameter
     REAL(wp) ::  dt_restart = 9999999.9_wp                     !< namelist parameter
     REAL(wp) ::  dt_run_control = 60.0_wp                      !< namelist parameter
     REAL(wp) ::  dt_spinup = 60.0_wp                           !< namelist parameter

--- a/trunk/SOURCE/parin.f90
+++ b/trunk/SOURCE/parin.f90
@@ -698,7 +698,7 @@
              dt, dt_averaging_input, dt_averaging_input_pr,                    &
              dt_coupling, dt_data_output, dt_data_output_av, dt_disturb,       &
              dt_domask, dt_dopr, dt_dopr_listing, dt_dots, dt_do2d_xy,         &
-             dt_do2d_xz, dt_do2d_yz, dt_do3d, dt_max, dt_restart,              &
+             dt_do2d_xz, dt_do2d_yz, dt_do3d, dt_max, dt_min, dt_restart,      &
              dt_run_control,end_time, force_print_header, mask_scale_x,        &
              mask_scale_y, mask_scale_z, mask_x, mask_y, mask_z, mask_x_loop,  &
              mask_y_loop, mask_z_loop, netcdf_data_format, netcdf_deflate,     &

--- a/trunk/SOURCE/parin.f90
+++ b/trunk/SOURCE/parin.f90
@@ -643,6 +643,7 @@
              scalar_rayleigh_damping, slope_offset, slope_normal_gradients,    &
              sigma_bulk, spinup_time, spinup_pt_amplitude, spinup_pt_mean,     &
              statistic_regions, stokes_force, stokes_drift_method,             &
+             stratification_affects_km,                                        &
              subs_vertical_gradient,                                           &
              subs_vertical_gradient_level, surface_flux_diags,                 &
              surface_heatflux, surface_pressure,                               &

--- a/trunk/SOURCE/surface_layer_fluxes_mod.f90
+++ b/trunk/SOURCE/surface_layer_fluxes_mod.f90
@@ -1658,7 +1658,7 @@
              
              surf%ol(m) = MAX(min_ol,                                          &
                               MIN(max_ol,                                      &
-                                  rho_ocean(k,j,i) * surf%us(m)**3 /           &
+                                  rho_ocean(k,j,i) * surf%us(m)**3.0_wp /      &
                                   ( g * kappa *                                &
                                     ( beta_S(k,j,i)*surf%sasws(m) -            &
                                       alpha_T(k,j,i)*surf%shf(m)    )          &

--- a/trunk/SOURCE/timestep.f90
+++ b/trunk/SOURCE/timestep.f90
@@ -129,7 +129,7 @@
         ONLY:  dzu, dzw, kh, km, ks, u, v, w
 
     USE control_parameters,                                                    &
-        ONLY:  cfl_factor, coupling_mode, dt_3d, dt_fixed, dt_max,             &
+        ONLY:  cfl_factor, coupling_mode, dt_3d, dt_fixed, dt_max, dt_min,     &
                galilei_transformation, old_dt, message_string, rans_mode,      &
                stop_dt, terminate_coupled, terminate_coupled_remote,           &
                timestep_reason, u_gtrans, use_ug_for_galilei_tr, v_gtrans
@@ -360,7 +360,7 @@
 
 !
 !--    Set flag if the time step becomes too small.
-       IF ( dt_3d < ( 0.00001_wp * dt_max ) )  THEN
+       IF ( dt_3d < ( 0.00001_wp * dt_max ) .OR. dt_3d < dt_min )  THEN
           stop_dt = .TRUE.
 
 !

--- a/trunk/SOURCE/turbulence_closure_mod.f90
+++ b/trunk/SOURCE/turbulence_closure_mod.f90
@@ -4280,15 +4280,13 @@
     REAL(wp)     ::  var_reference       !< reference temperature
     REAL(wp)     ::  km_max = 1e0_wp    !< maximum value of km
     REAL(wp)     ::  kden_min = 1e-10_wp  !< minimum value in denominator of diffusivity
-    REAL(wp)     ::  km_grav = 0.0_wp, km_num = 0.0_wp, kh_num = 0.0_wp,       &
-                     ks_num = 0.0_wp, km_den = 0.0_wp, kh_den = 0.0_wp,        &
-                     ks_den = 0.0_wp
+    REAL(wp)     ::  km_num = 0.0_wp, kh_num = 0.0_wp, ks_den = 0.0_wp,        &
+                     ks_num = 0.0_wp, km_den = 0.0_wp, kh_den = 0.0_wp         &
                      !< numerator and denominators of diffusivities
     REAL(wp)     ::  km_num_sum = 0.0_wp, km_den_sum = 0.0_wp,                 &
-                     km_grav_sum = 0.0_wp, km_sum = 0.0_wp, kh_sum = 0.0_wp,   &
-                     ks_sum = 0.0_wp
+                     km_sum = 0.0_wp, kh_sum = 0.0_wp, ks_sum = 0.0_wp
                      !< variables for diffusivity_diags
-
+    !REAL(wp)     ::  km_grav = 0.0_wp, km_grav_sum = 0.0_wp 
     REAL(wp), DIMENSION(3)   ::  dbdxi, dptdxi, dsadxi !< scalar gradients
     REAL(wp), DIMENSION(3,3) ::  dudxi, S              !< velocity gradients,
                                                        !< strain tensor
@@ -4369,7 +4367,7 @@
        !$OMP DO
        km_num_sum = 0.0_wp
        km_den_sum = 0.0_wp
-       km_grav_sum = 0.0_wp
+       !km_grav_sum = 0.0_wp
        km_sum = 0.0_wp
        kh_sum = 0.0_wp
        ks_sum = 0.0_wp
@@ -4385,7 +4383,7 @@
              DO  k = nzb+1, nzt
                 
                 km_num = 0.0_wp
-                km_grav = 0.0_wp
+                !km_grav = 0.0_wp
                 km_den = 0.0_wp
                 kh_num = 0.0_wp
                 kh_den = 0.0_wp
@@ -4424,16 +4422,19 @@
                       km_den = km_den + dudxi(jj,kk)**2.0_wp
                       kh_num = kh_num + dudxi(jj,kk) * dptdxi(kk) * dptdxi(jj)
                    ENDDO
-                   km_grav = km_grav - cos_alpha_surface * atmos_ocean_sign * g * &
-                                       dudxi(3,kk) * dbdxi(kk)
+                   !km_grav = km_grav - cos_alpha_surface * atmos_ocean_sign * g * &
+                   !                    dudxi(3,kk) * dbdxi(kk)
                    kh_den = kh_den + dptdxi(kk)**2.0_wp
                 ENDDO
                 
 !
 !--             Compute diffusities
                 km(k,j,i) = MIN( km_max,                                       &
-                            C(k) * MAX( -1.0_wp * km_num + km_grav, 0.0_wp ) * &
+                            C(k) * MAX( -1.0_wp * km_num, 0.0_wp ) *           &
                             flag / ( km_den + kden_min ) )
+                !km(k,j,i) = MIN( km_max,                                       &
+                !            C(k) * MAX( -1.0_wp * km_num + km_grav, 0.0_wp ) * &
+                !            flag / ( km_den + kden_min ) )
                 kh(k,j,i) = C(k) * MAX( -1.0_wp * kh_num, 0.0_wp ) * flag /    &
                             ( kh_den + kden_min )
                 
@@ -4453,7 +4454,7 @@
                    ks_sum      = ks_sum + ks(k,j,i)
                    km_num_sum  = km_num_sum + km_num
                    km_den_sum  = km_den_sum + km_den
-                   km_grav_sum = km_grav_sum + km_grav
+                   !km_grav_sum = km_grav_sum + km_grav
                    nn = nn + 1
                    IF ( km_num > 0.0_wp ) mm = mm + 1.0_wp
                 ENDIF
@@ -4463,8 +4464,8 @@
        ENDDO
        
        IF ( diffusivity_diags ) THEN
-          WRITE(message_string,*) 'km_grav_av(',klog,') = ',km_grav_sum/nn
-          CALL location_message(message_string,.TRUE.)
+          !WRITE(message_string,*) 'km_grav_av(',klog,') = ',km_grav_sum/nn
+          !CALL location_message(message_string,.TRUE.)
           WRITE(message_string,*) 'km_num_av(',klog,') = ',km_num_sum/nn
           CALL location_message(message_string,.TRUE.)
           WRITE(message_string,*) 'km_den_av(',klog,') = ',km_den_sum/nn


### PR DESCRIPTION
The stratification term in AMD closure is now off by default. See Issue https://github.com/xylar/palm_les_lanl/issues/69 for the reasoning behind this change. 

Another minor change included in this PR is a namelist option for minimum timestep `dt_min`; once the minimum timestep is reached the simulation is terminated. This functionality was previously in place except the minimum timestep was set to 1e-5 * maximum timestep. 