### PR TITLE
Add support for partial ice cover

### DIFF
--- a/compile_chicoma
+++ b/compile_chicoma
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+repo_path=$PWD
+build_path="/lustre/scratch5/$USER/palm/jobs/test-chicoma-build/"
+compile_debug="False"
+build_flags=""
+test_case="test_oceanml"
+
+if [[ ! -d $build_path ]]; then
+   mkdir -p $build_path
+fi
+
+if [[ ! -f $build_path/${test_case}_p3d ]]; then
+   if [[ -f ${test_case}_p3d ]]; then
+      cp ${test_case}_p3d $build_path/.
+   else
+      echo "${test_case}_p3d is not in $repo_path"
+   fi
+fi
+
+# Save git commit hash to make directory
+git rev-parse HEAD > $build_path"build_commit.txt"
+
+if [[ $compile_debug == "True" ]]; then
+    build_flags="-D"
+fi
+
+export PATH="$repo_path/trunk/SCRIPTS:$PATH"
+module purge
+module load PrgEnv-intel/8.3.3
+module load cray-mpich/8.1.21 # needed for cray-netcdf-hdf5parallel
+module load cmake/3.22.3
+module load cray-python/3.9.13.1
+module load craype-x86-rome
+module load cray-fftw/3.3.10.2
+module load cray-hdf5-parallel/1.12.2.1 # needed for cray-netcdf-hdf5parallel
+module load cray-netcdf-hdf5parallel/4.9.0.1
+
+export PATH=/lustre/scratch5/.mdt0/cbegeman/palm/bin:${PATH}
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${CRAY_LD_LIBRARY_PATH}
+
+palm_simple_build -b ifort.chicoma_hdf5 -w $build_path $build_flags

--- a/run_script_chicoma
+++ b/run_script_chicoma
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+#SBATCH  --job-name=PALM_TEST
+#SBATCH  --nodes=2
+#SBATCH  --ntasks-per-node=32
+#SBATCH  --output=PALM_TEST.%j
+#SBATCH  --exclusive
+#SBATCH --qos=debug
+#SBATCH --time=01:00:00
+#SBATCH -A t23_arctic
+
+use_hdf5="True"
+do_restart="False"
+
+do_coupled="False"
+# number of cores for atmosphere and ocean, respectively, only used when do_coupled = True
+# atm_cores + ocn_cores should be equal to $SLURM_NTASKS
+atm_cores=32
+ocn_cores=32
+
+test_case="test_oceanml"
+run_config="srun"
+#run_config="mpirun"
+openmp_threads=1
+repo_path=$PWD
+exec_path="/lustre/scratch5/$USER/palm/jobs/test-chicoma-build/"
+
+cd $SLURM_SUBMIT_DIR
+export PATH="$repo_path/trunk/SCRIPTS:${PATH}"
+
+module purge
+module load PrgEnv-intel/8.3.3
+module load cray-mpich/8.1.21
+module load cmake/3.22.3
+module load cray-python/3.9.13.1
+module load craype-x86-rome
+module load cray-fftw/3.3.10.2
+module load cray-hdf5-parallel/1.12.2.1
+module load cray-netcdf-hdf5parallel/4.9.0.1
+
+#get ntasks and nprocs from SLURM variables
+NTASKS=$SLURM_NTASKS
+nnodes=$SLURM_JOB_NUM_NODES
+NN=$((NTASKS/nnodes))
+
+echo "PROCS = $NN"
+
+timestring=`squeue -h -j $SLURM_JOBID -o "%l"`
+WTIME=`echo $timestring | sed -E 's/(.*):(.+):(.+)/\1*3600+\2*60+\3/;s/(.+):(.+)/\1*60+\2/' | bc`
+
+echo "WTIME = $WTIME"
+
+# set options for palm_simple_run
+palm_options="-w $exec_path -c $run_config -s $test_case -n $NN -p $NTASKS -t $openmp_threads -T $WTIME"
+
+palm_options="$palm_options -b ifort.chicoma_hdf5"
+
+if [[ $do_restart == "True" ]]; then
+    palm_options="$palm_options -r"
+fi
+
+if [[ $do_coupled == "True" ]]; then
+    palm_simple_run $palm_options -Y "$atm_cores $ocn_cores"
+else
+    palm_simple_run $palm_options
+fi

--- a/test_oceanml_p3d
+++ b/test_oceanml_p3d
@@ -36,10 +36,14 @@
         bc_sa_t = 'neumann', /
 
 &runtime_parameters
+        dt_min                     = 0.05,
         end_time = 3600.0,
+
         create_disturbances = .T.,
-!        disturbance_level_b = -4.,
+        disturbance_amplitude = 1e-2
+        disturbance_level_b = -40.,
         dt_disturb = 150.,
+
         dt_run_control = 0.0,
         dt_data_output = 3600.0,
         dt_dopr = 3600.0,

--- a/test_partialice_p3d
+++ b/test_partialice_p3d
@@ -61,7 +61,7 @@
         dt_data_output_av = 3600.,
         section_xy = 32,
 
-        data_output = 'melt*_xy', 'shf*_xy', 'sasws*_xy',
+        data_output = 'melt*_xy', 'shf*_xy', 'sasws*_xy', 'usws*_xy', 'vsws*_xy',
                       'e', 'pt', 'sa', 'u', 'v', 'w', 'rho_ocean', 'alpha_T',
 
         data_output_pr = 'e','e*', '#pt', '#sa', 'p', 'hyp', 'km', 'kh', 'l',

--- a/test_partialice_p3d
+++ b/test_partialice_p3d
@@ -1,0 +1,72 @@
+&initialization_parameters
+        nx = 31, ny = 31, nz=32,
+        dx = 2.5, dy = 2.5, dz = 2.5,
+
+        ocean = .T.,
+
+        initializing_actions = 'set_constant_profiles',
+
+        latitude = 55.6,
+
+        reference_state            = 'single_value',
+
+        rayleigh_damping_factor    = 0.0001,
+        rayleigh_damping_height    = -42.6667,
+
+        drag_law                   = 'businger',
+        drag_coeff                 = 0.003,
+        gamma_mcphee               = 'depth-dependent',
+        k_offset_mcphee            = 1,
+        koff_constant_mcphee       = .T.,
+
+        ug_surface = 0.0,
+        vg_surface = 0.0,
+        pt_surface                 = 293.0,
+        pt_vertical_gradient       = 1.0,
+        pt_vertical_gradient_level = 0.0,
+        sa_surface                 = 35.0,
+        sa_vertical_gradient       = 0.0,
+
+
+        ice_cover                  = 'read_from_file',
+        use_top_fluxes             = .T.,
+        use_surface_fluxes         = .F.,
+        constant_flux_layer        = 'top',
+        most_method                = 'mcphee',
+        surface_flux_diags         = .T.,
+
+        top_momentumflux_u         = 9999999.9,
+        top_momentumflux_v         = 9999999.9,
+
+        top_heatflux               = 1.78e-5,
+        surface_heatflux           = 9999999.9,
+
+        top_salinityflux           = 0.0,
+        bottom_salinityflux        = 9999999.9,
+
+        bc_uv_b = 'neumann', bc_uv_t = 'dirichlet',
+        bc_pt_b = 'dirichlet', bc_pt_t = 'neumann',
+        bc_p_b  = 'neumann',  bc_p_t  = 'neumann',
+        bc_s_b  = 'dirichlet',  bc_s_t  = 'neumann',
+        bc_sa_b = 'dirichlet', bc_sa_t = 'neumann', /
+
+&runtime_parameters
+        end_time = 3600.0,
+        create_disturbances = .T.,
+!        disturbance_level_b = -4.,
+        dt_disturb = 150.,
+        dt_run_control = 0.0,
+        dt_data_output = 3600.0,
+        dt_dopr = 3600.0,
+        dt_data_output_av = 3600.,
+        section_xy = 32,
+
+        data_output = 'melt*_xy', 'shf*_xy', 'sasws*_xy',
+                      'e', 'pt', 'sa', 'u', 'v', 'w', 'rho_ocean', 'alpha_T',
+
+        data_output_pr = 'e','e*', '#pt', '#sa', 'p', 'hyp', 'km', 'kh', 'l',
+              '#u','#v','w','prho','w"u"','w*u*','w"v"','w*v*','w"pt"','w*pt*',
+              'w"sa"','w*sa*','w*e*','u*2','v*2','w*2','pt*2','w*3','Sw',
+              'w*2pt*','w*pt*2','w*u*u*:dz','w*p*:dz','rho_ocean','alpha_T', /
+
+

--- a/test_tidalarctic_p3d
+++ b/test_tidalarctic_p3d
@@ -1,0 +1,66 @@
+&initialization_parameters
+        nx = 63, ny = 63, nz=64,
+        dx = 2.5, dy = 2.5, dz = 2.5,
+
+        ocean = .T.,
+
+        initializing_actions = 'set_constant_profiles',
+
+        latitude = 75,
+
+        reference_state            = 'single_value',
+
+        rayleigh_damping_factor    = 0.0001,
+        rayleigh_damping_height    = -100,
+
+        pt_surface                 = 293.0,
+        pt_vertical_gradient       = 1.0,
+        pt_vertical_gradient_level = 0.0,
+        sa_surface                 = 35.0,
+        sa_vertical_gradient       = 0.0,
+
+        ice_cover                  = 'none',
+        use_top_fluxes             = .F.,
+        use_surface_fluxes         = .F.,
+        surface_flux_diags         = .T.,
+
+        top_momentumflux_u         = 9999999.9,
+        top_momentumflux_v         = 9999999.9,
+
+        top_heatflux               = 9999999.9,
+        surface_heatflux           = 9999999.9,
+
+        top_salinityflux           = 9999999.9,
+        bottom_salinityflux        = 9999999.9,
+
+        dpdx                       = 0.01,
+        dpdx_freq                  = 2.24e-5,
+        dpdx_phase                 = 1.570796,
+        dp_level_b                 = -160.0,
+
+        bc_uv_b = 'neumann', bc_uv_t = 'neumann',
+        bc_pt_b = 'dirichlet', bc_pt_t = 'neumann',
+        bc_p_b  = 'neumann',  bc_p_t  = 'neumann',
+        bc_s_b  = 'dirichlet',  bc_s_t  = 'neumann',
+        bc_sa_b = 'dirichlet', bc_sa_t = 'neumann', /
+
+&runtime_parameters
+        end_time = 3600.0,
+        create_disturbances = .T.,
+!        disturbance_level_b = -4.,
+        dt_disturb = 150.,
+        dt_run_control = 0.0,
+        dt_data_output = 3600.0,
+        dt_dopr = 3600.0,
+        dt_data_output_av = 3600.,
+        section_xy = 32,
+
+        data_output = 'melt*_xy', 'shf*_xy', 'sasws*_xy', 'usws*_xy', 'vsws*_xy',
+                      'e', 'pt', 'sa', 'u', 'v', 'w', 'rho_ocean', 'alpha_T',
+
+        data_output_pr = 'e','e*', '#pt', '#sa', 'p', 'hyp', 'km', 'kh', 'l',
+              '#u','#v','w','prho','w"u"','w*u*','w"v"','w*v*','w"pt"','w*pt*',
+              'w"sa"','w*sa*','w*e*','u*2','v*2','w*2','pt*2','w*3','Sw',
+              'w*2pt*','w*pt*2','w*u*u*:dz','w*p*:dz','rho_ocean','alpha_T', /
+
+

--- a/trunk/INSTALL/MAKE.inc.ifort.chicoma_hdf5
+++ b/trunk/INSTALL/MAKE.inc.ifort.chicoma_hdf5
@@ -1,0 +1,12 @@
+# Contents of this file are included in palm's makefile if the simple install
+# process (palm_simple_install) is used.
+# Please adjust compiling parameters as required for your system.
+
+PROG=palm
+F90=mpif90
+F90_SER=ifort
+NETCDF_PATH=/opt/cray/pe/netcdf-hdf5parallel/4.9.0.1/intel/19.0
+HDF5_PATH=/opt/cray/pe/hdf5-parallel/1.12.2.1/intel/19.0
+COPT= -cpp -DMPI_REAL=MPI_DOUBLE_PRECISION -DMPI_2REAL=MPI_2DOUBLE_PRECISION -D__netcdf -D__netcdf4 -D__lc -D__parallel
+F90FLAGS=  -g -cpp -r8 -align all -ftz -fno-alias -no-scalar-rep -no-prec-div -no-prec-sqrt -ip -nbs -convert little_endian -I$(NETCDF_PATH)/include/
+LDFLAGS= -g -cpp -r8 -align all -ftz -fno-alias -no-scalar-rep -no-prec-div -no-prec-sqrt -ip -nbs -L$(NETCDF_PATH)/lib -L$(HDF5_PATH)/lib -lnetcdff -lnetcdf -lhdf5_hl -lhdf5 -lm

--- a/trunk/INSTALL/RUN.cmd.srun
+++ b/trunk/INSTALL/RUN.cmd.srun
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# The content of this file is included in the palm_simple_run
+# Please adjust execution parameters as required for your system.
+# PALM needs to be called as: ./palm
+# The following environment variables can be used:
+# ${mpi_ranks} is the total number of mpi ranks (option -p)
+# ${mpi_ranks_per_node} is the total number of mpi ranks per node (option -n)
+# ${openmp_threads} is the number of OpenMP threads (option -t)
+
+export OMP_NUM_THREADS=${openmp_threads}
+srun -n ${mpi_ranks} ./palm
+./combine_plot_fields.x

--- a/trunk/SCRIPTS/create_basic_static_driver.py
+++ b/trunk/SCRIPTS/create_basic_static_driver.py
@@ -1,0 +1,466 @@
+#!/usr/bin/env python3
+# -------------------------------------------------------------------- #
+# This file is part of the PALM model system.
+#
+# PALM is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# PALM is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PALM. If not, see <http://www.gnu.org/licenses/>.
+#
+# Copyright 1997-2021 Leibniz Universitaet Hannover
+# -------------------------------------------------------------------- #
+
+import datetime
+import math
+import pytz
+
+from netCDF4 import Dataset
+import numpy as np
+
+
+class StaticDriver:
+    """This is an example script to generate static drivers for PALM.
+
+    You can use it as a starting point for creating your setup specific
+    driver.
+    """
+
+    def __init__(self):
+        """Open the static driver as netCDF4 file. Here, you have to
+        give the full path to the static driver that shall be created.
+        Existing file with same name is deleted.
+        """
+        print('Opening file...')
+        self.nc_file = Dataset('example_static_file.nc', 'w', format='NETCDF4')
+
+    def write_global_attributes(self):
+        """Write global attributes to static driver."""
+        print("Writing global attributes...")
+
+        # Optional global attributes
+        # --------------------------
+        self.nc_file.title = 'Example PALM static driver'
+        self.nc_file.author = 'PALM user'
+        self.nc_file.institution = 'Institut of Meteorology and Climatology,' \
+            'Leibniz University Hannover'
+        self.nc_file.comment = 'Generic crossing example'
+        self.nc_file.creation_date = \
+            pytz.utc.localize(datetime.datetime.utcnow()).strftime('%y-%m-%d %H:%M:%S %z')[:-2]
+        self.nc_file.history = ''
+        self.nc_file.keywords = 'example, PALM-4U'
+        self.nc_file.license = ''
+        self.nc_file.palm_version = ''
+        self.nc_file.references = ''
+        self.nc_file.source = 'PALM trunk'
+        self.nc_file.version = '1'
+
+        # Mandatory global attributes
+        # ---------------------------
+        self.nc_file.Conventions = 'CF-1.7'
+        self.nc_file.origin_lat = 52.50965  # (overwrite initialization_parameters)
+        self.nc_file.origin_lon = 13.3139  # Used to initialize Coriolis parameter
+        self.nc_file.origin_time = '2019-03-06 10:00:00 +00'
+        self.nc_file.origin_x = 3455249.0
+        self.nc_file.origin_y = 5424815.0
+        self.nc_file.origin_z = 0.0
+        self.nc_file.rotation_angle = 0.0
+
+    def define_dimensions(self):
+        """Set dimensions on which variables are defined."""
+        print("Writing dimensions...")
+
+        # Specify general grid parameters
+        # These values must equal to those set in the initialization_parameters
+        self.nx = 19
+        self.ny = 19
+        self.nz = 20
+        dx = 2
+        dy = 2
+        dz = 2
+
+        # Create soil grid (only relevant if land surface module is used)
+        dz_soil = np.array((0.01, 0.02, 0.04, 0.06, 0.14, 0.26, 0.54, 1.86))
+        zsoil_fullLayers = np.zeros_like(dz_soil)
+        zsoil_fullLayers = np.around(
+            [np.sum(dz_soil[:zs]) for zs in np.arange(1, len(dz_soil)+1)], 2)
+        zsoil_array = zsoil_fullLayers - dz_soil/2.
+
+        # Coordinates
+        # -----------
+        self.nc_file.createDimension('x', self.nx+1)
+        self.x = self.nc_file.createVariable('x', 'f4', ('x',))
+        self.x.long_name = 'distance to origin in x-direction'
+        self.x.units = 'm'
+        self.x.axis = 'X'
+        self.x[:] = np.arange(0, (self.nx+1)*dx, dx) + 0.5 * dx
+
+        self.nc_file.createDimension('y', self.ny+1)
+        self.y = self.nc_file.createVariable('y', 'f4', ('y',))
+        self.y.long_name = 'distance to origin in y-direction'
+        self.y.units = 'm'
+        self.y.axis = 'Y'
+        self.y[:] = np.arange(0, (self.ny+1)*dy, dy) + 0.5 * dy
+
+        # NOTE if your simulation uses a stretched vertical grid, you
+        # need to modify the z coordinates, e.g. z_array = (...)
+        z_array = np.append(0, np.arange(dz/2, (self.nz)*dz, dz))
+        self.nc_file.createDimension('z', self.nz+1)
+        self.z = self.nc_file.createVariable('z', 'f4', ('z',))
+        self.z.long_name = 'height above origin'
+        self.z.units = 'm'
+        self.z.axis = 'Z'
+        self.z.positive = 'up'
+        self.z[:] = z_array
+
+        zlad_array = self.z[:6]
+        self.nc_file.createDimension('zlad', len(zlad_array))
+        self.zlad = self.nc_file.createVariable('zlad', 'f4', ('zlad',))
+        self.zlad.long_name = 'height above ground'
+        self.zlad.units = 'm'
+        self.zlad.axis = 'Z'
+        self.zlad.positive = 'up'
+        self.zlad[:] = zlad_array
+
+        # self.nc_file.createDimension('zsoil', len(zsoil_array))
+        # self.zsoil = self.nc_file.createVariable('zsoil', 'f4', ('zsoil',))
+        # self.zsoil.long_name = 'depth in the soil'
+        # self.zsoil.units = 'm'
+        # self.zsoil.axis = 'Z'
+        # self.zsoil.positive = 'down'
+        # self.zsoil[:] = zsoil_array
+
+        # Other dimensions
+        # ----------------
+        # self.nc_file.createDimension('nalbedo_pars', 3)
+        # self.nalbedo_pars = self.nc_file.createVariable(
+        #     'nalbedo_pars', 'i4', ('nalbedo_pars',))
+        # self.nalbedo_pars[:] = np.arange(8)
+        #
+        # self.nc_file.createDimension('nbuilding_pars', 149)
+        # self.nbuilding_pars = self.nc_file.createVariable(
+        #     'nbuilding_pars', 'i4', ('nbuilding_pars',))
+        # self.nbuilding_pars[:] = np.arange(149)
+        #
+        # self.nc_file.createDimension('npavement_pars', 4)
+        # self.npavement_pars = self.nc_file.createVariable(
+        #     'npavement_pars', 'i4', ('npavement_pars',))
+        # self.npavement_pars[:] = np.arange(4)
+        #
+        # self.nc_file.createDimension('npavement_subsurface_pars', 2)
+        # self.npavement_subsurface_pars = self.nc_file.createVariable(
+        #     'npavement_subsurface_pars', 'i4', ('npavement_subsurface_pars',))
+        # self.npavement_subsurface_pars[:] = np.arange(2)
+        #
+        # self.nc_file.createDimension('nsoil_pars', 8)
+        # self.nsoil_pars = self.nc_file.createVariable(
+        #     'nsoil_pars', 'i4', ('nsoil_pars',))
+        # self.nsoil_pars[:] = np.arange(8)
+        #
+        self.nc_file.createDimension('nsurface_fraction', 3)
+        self.nsurface_fraction = self.nc_file.createVariable(
+            'nsurface_fraction', 'i4', ('nsurface_fraction',))
+        self.nsurface_fraction[:] = np.arange(3)
+
+        # self.nc_file.createDimension('nvegetation_pars', 12)
+        # self.nvegetation_pars = self.nc_file.createVariable(
+        #     'nvegetation_pars', 'i4', ('nvegetation_pars',))
+        # self.nvegetation_pars[:] = np.arange(12)
+        #
+        # self.nc_file.createDimension('nwater_pars', 6)
+        # self.nwater_pars = self.nc_file.createVariable(
+        #     'nwater_pars', 'i4', ('nwater_pars',))
+        # self.nwater_pars[:] = np.arange(7)
+
+    def define_variables(self):
+        """Define variables for the static driver.
+
+        Be aware that some variables depend on others. For a description
+        of each variable, please have a look at the documentation at
+        palm.muk.uni-hannover.de/trac/wiki/doc/app/iofiles/pids/static
+
+        An example of how you modify the variables is given below:
+
+        building_2d_array = np.ones((self.ny+1, self.nx+1)) * -9999.0
+        south_wall, north_wall, left_wall, right_wall = 20, 25, 20, 25
+        building_2d_array[
+            south_wall:north_wall,
+            left_wall:right_wall
+            ] = 50
+        nc_buildings_2d = self.nc_file.createVariable(
+            'buildings_2d', 'f4', ('y', 'x'), fill_value=-9999.0)
+        nc_buildings_2d.lod = 1
+        nc_buildings_2d[:, :] = building_2d_array
+        """
+        print("Writing variables...")
+
+        # Topography set-up
+        # -----------------
+        nc_building_id = self.nc_file.createVariable(
+            'building_id', 'i4', ('y', 'x'), fill_value=-9999)
+        nc_building_id.long_name = "building id number"
+        nc_building_id.units = "1"
+        nc_building_id[:, :] = nc_building_id._FillValue
+
+        nc_buildings_2d = self.nc_file.createVariable(
+            'buildings_2d', 'f4', ('y', 'x'), fill_value=-9999.0)
+        nc_buildings_2d.long_name = "building height"
+        nc_buildings_2d.units = "m"
+        nc_buildings_2d.lod = np.int32(1)
+        nc_buildings_2d[:, :] = nc_buildings_2d._FillValue
+
+        nc_buildings_3d = self.nc_file.createVariable(
+            'buildings_3d', 'i1', ('z', 'y', 'x'), fill_value=-127)
+        nc_buildings_3d.long_name = "building flag"
+        nc_buildings_3d.units = "1"
+        nc_buildings_3d.lod = np.int32(2)
+        nc_buildings_3d[:, :, :] = nc_buildings_3d._FillValue
+
+        nc_zt = self.nc_file.createVariable(
+            'zt', 'f4', ('y', 'x'), fill_value=-9999.0)
+        nc_zt.long_name = 'terrain height'
+        nc_zt.units = 'm'
+        nc_zt[:, :] = nc_zt._FillValue
+
+        # nc_z0 = self.nc_file.createVariable(
+        #     'z0', 'f4', ('y', 'x'), fill_value=-9999.0)
+        # nc_z0.long_name = 'roughness length for momentum'
+        # nc_z0.units = 'm'
+        # nc_z0[:, :] = nc_z0._FillValue
+
+        # Main surface clasification
+        # --------------------------
+        # nc_albedo_type = self.nc_file.createVariable(
+        #     'albedo_type', 'f4', ('y', 'x'), fill_value=-9999.0)
+        # nc_albedo_type.long_name = "albedo type"
+        # nc_albedo_type.units = "1"
+        # nc_albedo_type[:, :] = nc_albedo_type._FillValue
+        #
+        nc_building_type = self.nc_file.createVariable(
+            'building_type', 'i1', ('y', 'x'), fill_value=-127)
+        nc_building_type.long_name = "building type classification"
+        nc_building_type.units = "1"
+        nc_building_type[:, :] = nc_building_type._FillValue
+
+        nc_pavement_type = self.nc_file.createVariable(
+            'pavement_type', 'i1', ('y', 'x'), fill_value=-127)
+        nc_pavement_type.long_name = "pavement type classification"
+        nc_pavement_type.units = "1"
+        nc_pavement_type[:, :] = nc_pavement_type._FillValue
+
+        nc_soil_type = self.nc_file.createVariable(
+            'soil_type', 'i1', ('y', 'x'), fill_value=-127)
+        nc_soil_type.long_name = "soil type classification"
+        nc_soil_type.units = "1"
+        nc_soil_type.lod = np.int32(1)
+        nc_soil_type[:, :] = nc_soil_type._FillValue
+
+        # NOTE alternatively, define different soil types for different
+        # soil layers
+        # nc_soil_type = self.nc_file.createVariable(
+        #     'soil_type', 'i1', ('zsoil', 'y', 'x'), fill_value=-127)
+        # nc_soil_type.long_name = "soil type"
+        # nc_soil_type.units = "1"
+        # nc_soil_type.lod = np.int32(2)
+        # nc_soil_type[:, :, :] = nc_soil_type._FillValue
+        #
+        # nc_street_crossing = self.nc_file.createVariable(
+        #     'street_crossing', 'i1', ('y', 'x'),
+        #     fill_value=-127)
+        # nc_street_crossing.long_name = "street crossing"
+        # nc_street_crossing.units = "1"
+        # nc_street_crossing.valid_range = np.byte(1)
+        # nc_street_crossing[:, :] = nc_street_crossing._FillValue
+        #
+        nc_street_type = self.nc_file.createVariable(
+            'street_type', 'i1', ('y', 'x'),
+            fill_value=-127)
+        nc_street_type.long_name = "street type classification"
+        nc_street_type.units = "1"
+        nc_street_type[:, :] = nc_street_type._FillValue
+
+        nc_surface_fraction = self.nc_file.createVariable(
+            'surface_fraction', 'f4', ('nsurface_fraction', 'y', 'x'), fill_value=-9999.0)
+        nc_surface_fraction.long_name = "surface fraction"
+        nc_surface_fraction.units = "1"
+        nc_surface_fraction[0, :, :] = nc_surface_fraction._FillValue  # vegetation fraction
+        nc_surface_fraction[1, :, :] = nc_surface_fraction._FillValue  # pavement fraction
+        nc_surface_fraction[2, :, :] = nc_surface_fraction._FillValue  # water fraction
+
+        nc_vegetation_type = self.nc_file.createVariable(
+            'vegetation_type', 'i1', ('y', 'x'), fill_value=-127)
+        nc_vegetation_type.long_name = "vegetation type classification"
+        nc_vegetation_type.units = "1"
+        nc_vegetation_type[:, :] = nc_vegetation_type._FillValue
+
+        nc_water_type = self.nc_file.createVariable(
+            'water_type', 'i1', ('y', 'x'), fill_value=-127)
+        nc_water_type.long_name = "water type classification"
+        nc_water_type.units = "1"
+        nc_water_type[:, :] = nc_water_type._FillValue
+
+        # Pixel-based surface and sub-surface parameters
+        # ----------------------------------------------
+        # nc_albedo_pars = self.nc_file.createVariable(
+        #     'albedo_pars', 'f4', ('nalbedo_pars', 'y', 'x'), fill_value=-9999.0)
+        # nc_albedo_pars.long_name = 'albedo parameters'
+        # nc_albedo_pars[:, :, :] = nc_albedo_pars._FillValue
+        #
+        # nc_building_pars = self.nc_file.createVariable(
+        #     'building_pars', 'f4', ('nbuilding_pars', 'y', 'x'), fill_value=-9999.0)
+        # nc_building_pars.long_name = 'building parameters'
+        # nc_building_pars[:, :, :] = nc_building_pars._FillValue
+        #
+        # nc_pavement_pars = self.nc_file.createVariable(
+        #     'pavement_pars', 'f4', ('npavement_pars', 'y', 'x'), fill_value=-9999.0)
+        # nc_pavement_pars.long_name = "pavement parameters"
+        # nc_pavement_pars[:, :, :] = nc_pavement_pars._FillValue
+        #
+        # nc_pavement_subsurface_pars = self.nc_file.createVariable(
+        #     'pavement_subsurface_pars', 'i1',
+        #     ('npavement_subsurface_pars','zsoil', 'y', 'x'), fill_value=-9999.0)
+        # nc_pavement_subsurface_pars.long_name = "pavement subsurface parameters"
+        # nc_pavement_subsurface_pars[:, :, :, :] = nc_pavement_subsurface_pars._FillValue
+        #
+        # nc_soil_pars = self.nc_file.createVariable(
+        #     'soil_pars', 'f', ('nsoil_pars','zsoil', 'y', 'x'), fill_value=-9999.0)
+        # nc_soil_pars.long_name = "soil parameters"
+        # nc_soil_pars.lod = np.int32(2) # if set to 1, adjust dimensions of soil_pars
+        # nc_soil_pars[:, :, :, :] = nc_soil_pars._FillValue
+        #
+        # nc_vegetation_pars = self.nc_file.createVariable(
+        #     'vegetation_pars', 'f', ('nvegetation_pars', 'y', 'x'), fill_value=-9999.0)
+        # nc_vegetation_pars.long_name = 'vegetation parameters'
+        # nc_vegetation_pars[:, :, :] = nc_vegetation_pars._FillValue
+        #
+        # nc_water_pars = self.nc_file.createVariable(
+        #     'water_pars', 'i1', ('nwater_pars', 'y', 'x'), fill_value=-9999.0)
+        # nc_water_pars.long_name = "water parameters"
+        # nc_water_pars[:, :, :] = nc_water_pars._FillValue
+
+        # Vegetation parameters
+        # ---------------------
+        nc_lad = self.nc_file.createVariable(
+            'lad', 'f4', ('zlad', 'y', 'x'), fill_value=-9999.0)
+        nc_lad.long_name = "leaf area density"
+        nc_lad.units = "m2 m-3"
+        nc_lad[:, :, :] = nc_lad._FillValue
+
+        # nc_bad = self.nc_file.createVariable(
+        #     'bad', 'f4', ('zlad', 'y', 'x'), fill_value=-9999.0)
+        # nc_bad.long_name = "basal area density"
+        # nc_bad.units = "m2 m-3"
+        # nc_bad[:, :, :] = nc_bad._FillValue
+        #
+        # nc_root_area_dens_r = self.nc_file.createVariable(
+        #     'root_area_dens_s', 'f4', ('zsoil', 'y', 'x'), fill_value=-9999.0)
+        # nc_root_area_dens_r.long_name = 'root area density of resolved vegetation'
+        # nc_root_area_dens_r.units = '1'
+        # nc_root_area_dens_r[:, :, :] = nc_root_area_dens_r._FillValue
+        #
+        # nc_root_area_dens_s = self.nc_file.createVariable(
+        #     'root_area_dens_s', 'f4', ('zsoil', 'y', 'x'), fill_value=-9999.0)
+        # nc_root_area_dens_s.long_name = 'root area density of parameterized vegetation'
+        # nc_root_area_dens_s.units = '1'
+        # nc_root_area_dens_s[:, :, :] = nc_root_area_dens_s._FillValue
+        #
+        # nc_tree_id = self.nc_file.createVariable(
+        #     'tree_id', 'i4', ('y', 'x'), fill_value=-9999.0)
+        # nc_tree_id.long_name = "tree id"
+        # nc_tree_id.units = "1"
+        # nc_tree_id[:, :, :] = nc_tree_id._FillValue
+
+        # Set topography
+        # --------------
+        nc_building_id[:5, :5] = 1
+        nc_building_id[-5:, :5] = 2
+        nc_building_id[:5, -5:] = 3
+        nc_building_id[-5:, -5:] = 4
+
+        nc_buildings_2d[:, :] = np.where(
+            nc_building_id[:, :] > nc_building_id._FillValue,
+            nc_building_id[:, :] * 10.0,
+            nc_buildings_2d[:, :])
+
+        for k in range(self.nz+1):
+            nc_buildings_3d[k, :, :] = np.where(nc_buildings_2d[:, :] > self.z[k], 1, 0)
+
+        nc_zt[:, :] = 4.0
+
+        # Set surface types
+        # -----------------
+        nc_building_type[:, :] = np.where(
+            nc_building_id[:, :] > nc_building_id._FillValue,
+            nc_building_id[:, :] * 1,
+            nc_building_type[:, :])
+
+        nc_pavement_type[9:11, :5] = 1
+        nc_pavement_type[:, 7:13] = 2
+
+        nc_vegetation_type[:, 5:7] = 3
+        nc_vegetation_type[:, 13:15] = 3
+        nc_vegetation_type[5:15, 15:] = 3
+        nc_vegetation_type[7:9, 15:17] = 1
+        nc_vegetation_type[11:13, 15:17] = 1
+
+        nc_water_type[5:9, :5] = 2
+        nc_water_type[11:15, :5] = 2
+
+        nc_soil_type[:, :] = np.where(
+            nc_vegetation_type[:, :] > nc_vegetation_type._FillValue,
+            2,
+            nc_soil_type[:, :])
+        nc_soil_type[:, :] = np.where(
+            nc_pavement_type[:, :] > nc_pavement_type._FillValue,
+            2,
+            nc_soil_type[:, :])
+
+        nc_street_type[:, :] = np.where(nc_pavement_type[:, :] == 1, 11, nc_street_type[:, :])
+        nc_street_type[:, :] = np.where(nc_pavement_type[:, :] == 2, 13, nc_street_type[:, :])
+
+        nc_surface_fraction[0, :, :] = np.where(
+            nc_building_id[:, :] > nc_building_id._FillValue,
+            nc_surface_fraction[0, :, :],
+            0)
+        nc_surface_fraction[2, :, :] = nc_surface_fraction[1, :, :] = nc_surface_fraction[0, :, :]
+        nc_surface_fraction[0, :, :] = np.where(
+            nc_vegetation_type[:, :] > nc_vegetation_type._FillValue,
+            1,
+            nc_surface_fraction[0, :, :])
+        nc_surface_fraction[1, :, :] = np.where(
+            nc_pavement_type[:, :] > nc_pavement_type._FillValue,
+            1,
+            nc_surface_fraction[1, :, :])
+        nc_surface_fraction[2, :, :] = np.where(
+            nc_water_type[:, :] > nc_water_type._FillValue,
+            1,
+            nc_surface_fraction[2, :, :])
+
+        # Set vegetation
+        # --------------
+        lad_profile = [0.0, 0.01070122, 0.1070122, 0.3130108, 0.3879193, 0.1712195]
+        for k in range(len(self.zlad)):
+            nc_lad[k, 7:9, 15:17] = lad_profile[k]
+            nc_lad[k, 11:13, 15:17] = lad_profile[k]
+
+    def finalize(self):
+        """Close file."""
+        print("Closing file...")
+
+        self.nc_file.close()
+
+
+if __name__ == '__main__':
+    driver = StaticDriver()
+    driver.write_global_attributes()
+    driver.define_dimensions()
+    driver.define_variables()
+    driver.finalize()
+

--- a/trunk/SCRIPTS/create_icecover_static_driver.py
+++ b/trunk/SCRIPTS/create_icecover_static_driver.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+# -------------------------------------------------------------------- #
+# This file is part of the PALM model system.
+#
+# PALM is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# PALM is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PALM. If not, see <http://www.gnu.org/licenses/>.
+#
+# Copyright 1997-2021 Leibniz Universitaet Hannover
+# -------------------------------------------------------------------- #
+
+import datetime
+import math
+import pytz
+
+from netCDF4 import Dataset
+import numpy as np
+
+
+class StaticDriver:
+    """This is an example script to generate static drivers for PALM.
+
+    You can use it as a starting point for creating your setup specific
+    driver.
+    """
+
+    def __init__(self):
+        """Open the static driver as netCDF4 file. Here, you have to
+        give the full path to the static driver that shall be created.
+        Existing file with same name is deleted.
+        """
+        print('Opening file...')
+        self.nc_file = Dataset('PIDS_STATIC', 'w', format='NETCDF4')
+
+    def write_global_attributes(self):
+        """Write global attributes to static driver."""
+        print("Writing global attributes...")
+
+        # Optional global attributes
+        # --------------------------
+        self.nc_file.title = 'PALM sea ice static driver'
+        self.nc_file.author = 'cbegeman'
+        self.nc_file.institution = 'Los Alamos National Laboratory'
+        self.nc_file.comment = 'ice cover characteristic of sea ice lead'
+        self.nc_file.creation_date = \
+            pytz.utc.localize(datetime.datetime.utcnow()).strftime('%y-%m-%d %H:%M:%S %z')[:-2]
+        self.nc_file.history = ''
+        self.nc_file.keywords = ''
+        self.nc_file.license = ''
+        self.nc_file.palm_version = ''
+        self.nc_file.references = ''
+        self.nc_file.source = 'PALM trunk'
+        self.nc_file.version = '1'
+
+        # Mandatory global attributes
+        # ---------------------------
+        self.nc_file.Conventions = 'CF-1.7'
+        self.nc_file.origin_lat = 52.50965  # (overwrite initialization_parameters)
+        self.nc_file.origin_lon = 13.3139  # Used to initialize Coriolis parameter
+        self.nc_file.origin_time = '2019-03-06 10:00:00 +00'
+        self.nc_file.origin_x = 3455249.0
+        self.nc_file.origin_y = 5424815.0
+        self.nc_file.origin_z = 0.0
+        self.nc_file.rotation_angle = 0.0
+
+    def define_dimensions(self):
+        """Set dimensions on which variables are defined."""
+        print("Writing dimensions...")
+
+        # Specify general grid parameters
+        # These values must equal to those set in the initialization_parameters
+        self.nx = 31
+        self.ny = 31
+        self.nz = 32
+        dx = 2.5
+        dy = 2.5
+        dz = 2.5
+
+        # Coordinates
+        # -----------
+        self.nc_file.createDimension('x', self.nx+1)
+        self.x = self.nc_file.createVariable('x', 'f4', ('x',))
+        self.x.long_name = 'distance to origin in x-direction'
+        self.x.units = 'm'
+        self.x.axis = 'X'
+        lx = (self.nx+1)*dx
+        self.x[:] = np.arange(0, lx, dx) + 0.5 * dx
+
+        self.nc_file.createDimension('y', self.ny+1)
+        self.y = self.nc_file.createVariable('y', 'f4', ('y',))
+        self.y.long_name = 'distance to origin in y-direction'
+        self.y.units = 'm'
+        self.y.axis = 'Y'
+        self.y[:] = np.arange(0, (self.ny+1)*dy, dy) + 0.5 * dy
+
+        # NOTE if your simulation uses a stretched vertical grid, you
+        # need to modify the z coordinates, e.g. z_array = (...)
+        z_array = np.append(0, np.arange(dz/2, (self.nz)*dz, dz))
+        self.nc_file.createDimension('z', self.nz+1)
+        self.z = self.nc_file.createVariable('z', 'f4', ('z',))
+        self.z.long_name = 'height above origin'
+        self.z.units = 'm'
+        self.z.axis = 'Z'
+        self.z.positive = 'up'
+        self.z[:] = z_array
+
+        zlad_array = self.z[:6]
+        self.nc_file.createDimension('zlad', len(zlad_array))
+        self.zlad = self.nc_file.createVariable('zlad', 'f4', ('zlad',))
+        self.zlad.long_name = 'height above ground'
+        self.zlad.units = 'm'
+        self.zlad.axis = 'Z'
+        self.zlad.positive = 'up'
+        self.zlad[:] = zlad_array
+
+        self.nc_file.createDimension('ntop_surface_fraction', 1)
+        self.ntop_surface_fraction = self.nc_file.createVariable(
+            'ntop_surface_fraction', 'i4', ('ntop_surface_fraction',))
+        self.ntop_surface_fraction[:] = np.arange(1)
+
+    def define_variables(self):
+        """Define variables for the static driver.
+
+        Be aware that some variables depend on others. For a description
+        of each variable, please have a look at the documentation at
+        palm.muk.uni-hannover.de/trac/wiki/doc/app/iofiles/pids/static
+
+        An example of how you modify the variables is given below:
+
+        building_2d_array = np.ones((self.ny+1, self.nx+1)) * -9999.0
+        south_wall, north_wall, left_wall, right_wall = 20, 25, 20, 25
+        building_2d_array[
+            south_wall:north_wall,
+            left_wall:right_wall
+            ] = 50
+        nc_buildings_2d = self.nc_file.createVariable(
+            'buildings_2d', 'f4', ('y', 'x'), fill_value=-9999.0)
+        nc_buildings_2d.lod = 1
+        nc_buildings_2d[:, :] = building_2d_array
+        """
+        print("Writing variables...")
+
+        # Main surface clasification
+        # --------------------------
+        nc_top_surface_fraction = self.nc_file.createVariable(
+            'top_surface_fraction', 'f4', ('ntop_surface_fraction', 'y', 'x'), fill_value=-9999.0)
+        nc_top_surface_fraction.long_name = "top surface fraction of ice"
+        nc_top_surface_fraction.units = "1"
+        nc_top_surface_fraction[0, :, :] = nc_top_surface_fraction._FillValue  # ice fraction
+
+        lx = self.x[-1]
+        print(self.x[:])
+        xarray, _ = np.meshgrid(self.x[:], self.y[:])
+        ice_mask = np.logical_or(xarray < lx/3, xarray > 2*lx/3)
+        nc_top_surface_fraction[0, :, :] = np.where(ice_mask, 1.0, 0.0)
+
+    def finalize(self):
+        """Close file."""
+        print("Closing file...")
+
+        self.nc_file.close()
+
+
+if __name__ == '__main__':
+    driver = StaticDriver()
+    driver.write_global_attributes()
+    driver.define_dimensions()
+    driver.define_variables()
+    driver.finalize()
+

--- a/trunk/SCRIPTS/palm_simple_run
+++ b/trunk/SCRIPTS/palm_simple_run
@@ -254,6 +254,10 @@ else
    else
       rm -r ${execution_dir}
       mkdir -p ${execution_dir}
+      if [[ -f ${working_dir}/PIDS_STATIC ]]
+      then
+         cp ${working_dir}/PIDS_STATIC ${execution_dir}/.
+      fi
    fi
 fi
 echo "*** PALM running in directory ${execution_dir}"

--- a/trunk/SOURCE/Makefile
+++ b/trunk/SOURCE/Makefile
@@ -489,6 +489,7 @@ SOURCES = \
 	global_min_max.f90 \
 	gust_mod.f90 \
 	header.f90 \
+	ice_surface_mod.f90 \
 	inflow_turbulence.f90 \
 	init_3d_model.f90 \
 	init_advec.f90 \
@@ -937,6 +938,8 @@ header.o: \
 	subsidence_mod.o \
 	surface_mod.o \
 	virtual_flight_mod.o
+ice_surface_mod.o: \
+	netcdf_data_input_mod.o
 inflow_turbulence.o: \
 	cpulog_mod.o \
 	mod_kinds.o \

--- a/trunk/SOURCE/Makefile
+++ b/trunk/SOURCE/Makefile
@@ -939,7 +939,10 @@ header.o: \
 	surface_mod.o \
 	virtual_flight_mod.o
 ice_surface_mod.o: \
-	netcdf_data_input_mod.o
+	mod_kinds.o \
+	modules.o \
+	netcdf_data_input_mod.o \
+	surface_mod.o
 inflow_turbulence.o: \
 	cpulog_mod.o \
 	mod_kinds.o \
@@ -950,6 +953,7 @@ init_3d_model.o: \
 	cpulog_mod.o \
 	disturb_heatflux.o \
 	gust_mod.o \
+	ice_surface_mod.o \
 	land_surface_model_mod.o \
 	large_scale_forcing_nudging_mod.o \
 	lpm_init.o \

--- a/trunk/SOURCE/header.f90
+++ b/trunk/SOURCE/header.f90
@@ -1078,6 +1078,12 @@
 
     END SELECT
 
+    IF ( TRIM( ice_cover ) /= 'full' .AND. &
+         TRIM( ice_cover ) /= 'read_from_file')  THEN
+       WRITE(message_string,*) 'Ice cover option is not supported.'
+       CALL message( 'surface_layer_fluxes', 'PA0655', 3, 2, 0, 6, 0 )
+    ENDIF
+
     IF ( TRIM( topography ) /= 'flat' )  THEN
        IF ( TRIM( topography_grid_convention ) == ' ' )  THEN
           IF ( TRIM( topography ) == 'single_building' .OR.  &

--- a/trunk/SOURCE/ice_surface_mod.f90
+++ b/trunk/SOURCE/ice_surface_mod.f90
@@ -1,0 +1,44 @@
+ MODULE ice_surface_mod
+
+    IMPLICIT NONE
+
+    PUBLIC initialize_ice_surface
+
+CONTAINS
+
+!------------------------------------------------------------------------------!
+! Description:
+! ------------
+!> Initialize horizontal surface elements, upward- and downward-facing. 
+!> Note, horizontal surface type also comprises model-top fluxes, which are,
+!> initialized in a different routine. 
+!------------------------------------------------------------------------------!
+   SUBROUTINE initialize_ice_surface( surf, num_h )
+   
+      USE control_parameters, ONLY: ice_cover
+   
+      USE netcdf_data_input_mod,                       &
+          ONLY :  input_pids_static,                   &
+                  top_surface_fraction_f
+   
+      IMPLICIT NONE 
+   
+      TYPE( surf_type ) :: surf          !< respective surface type
+      INTEGER(iwp)  ::  num_h            !< current number of surface element
+   
+      IF ( TRIM(ice_cover) == 'full' ) THEN
+         surf%ice_fraction(num_h) = 1.0_wp
+      ELSEIF ( TRIM(ice_cover) == 'read_from_file' ) THEN
+         IF ( input_pids_static .AND. top_surface_fraction_f%from_file ) THEN
+            !TODO assign from netcdf
+            surf%ice_fraction(num_h) = &
+               top_surface_fraction_f%frac(0,surf%j(num_h),surf%i(num_h))
+         ELSE
+            WRITE( message_string,* ) 'top_surface_fraction not properly initialized'
+            CALL message( 'surface_mod', 'PA0999', 1, 2, 0, 6, 0 )
+         ENDIF
+      ENDIF
+   
+   ENDSUBROUTINE initialize_ice_surface
+ 
+ END MODULE ice_surface_mod

--- a/trunk/SOURCE/init_3d_model.f90
+++ b/trunk/SOURCE/init_3d_model.f90
@@ -497,37 +497,40 @@
 
     USE constants,                                                             &
         ONLY:  pi, cpw
-    
+
     USE cpulog,                                                                &
         ONLY: cpu_log, log_point
         
     USE control_parameters
-    
+
     USE cpulog,                                                                &
         ONLY:  cpu_log, log_point, log_point_s
-    
+
     USE eqn_state_seawater_mod,                                                &
         ONLY:  eqn_state_seawater, eqn_state_seawater_func
 
     USE flight_mod,                                                            &
         ONLY:  flight_init
-    
+
     USE grid_variables,                                                        &
         ONLY:  dx, dy, ddx2_mg, ddy2_mg
 
     USE gust_mod,                                                              &
         ONLY:  gust_init, gust_init_arrays, gust_module_enabled
-    
+
+    USE ice_surface_mod,                                                &
+        ONLY:  ice_init
+
     USE indices
 
     USE lpm_init_mod,                                                          &
         ONLY:  lpm_init
-    
+
     USE kinds
 
     USE land_surface_model_mod,                                                &
         ONLY:  lsm_init, lsm_init_arrays
-  
+
     USE lsf_nudging_mod,                                                       &
         ONLY:  lsf_init, ls_forcing_surf, nudge_init
 
@@ -543,12 +546,12 @@
 
     USE netcdf_data_input_mod,                                                 &
         ONLY:  init_3d, netcdf_data_input_interpolate, netcdf_data_input_init_3d
-    
+
     USE particle_attributes,                                                   &
         ONLY:  particle_advection, use_sgs_for_particles, wang_kernel
-    
+
     USE pegrid
-    
+
     USE plant_canopy_model_mod,                                                &
         ONLY:  pcm_init
 
@@ -562,15 +565,15 @@
                radiation_interaction, radiation_interactions,                  &
                radiation_interaction_init, radiation_read_svf,                 &
                radiation_presimulate_solar_pos, radiation_interactions_on
-    
+
     USE random_function_mod 
-    
+
     USE random_generator_parallel,                                             &
         ONLY:  init_parallel_random_generator
 
     USE read_restart_data_mod,                                                 &
         ONLY:  rrd_read_parts_of_global, rrd_local                                      
-    
+
     USE statistics,                                                            &
         ONLY:  hom, hom_sum, mean_surface_level_height, pr_palm, rmask,        &
                statistic_regions, sums, sums_divnew_l, sums_divold_l, sums_l,  &
@@ -586,7 +589,7 @@
     USE surface_mod,                                                           &
         ONLY :  init_surface_arrays, init_surfaces, surf_def_h, surf_lsm_h,    &
                 surf_usm_h, get_topography_top_index_ji, vertical_surfaces_exist
-   
+
     USE transpose_indices
 
     USE turbulence_closure_mod,                                                &
@@ -2446,6 +2449,15 @@
     IF ( land_surface )  THEN
        CALL location_message( 'initializing land surface model', .FALSE. )
        CALL lsm_init
+       CALL location_message( 'finished', .TRUE. )
+    ENDIF
+
+!
+!-- Allocate ice surface model arrays
+    IF ( TRIM( ice_cover ) == 'full' .OR. &
+         TRIM( ice_cover ) == 'read_from_file')  THEN
+       CALL location_message( 'initializing ice surface model', .FALSE. )
+       CALL ice_init
        CALL location_message( 'finished', .TRUE. )
     ENDIF
 

--- a/trunk/SOURCE/modules.f90
+++ b/trunk/SOURCE/modules.f90
@@ -1364,7 +1364,6 @@
     LOGICAL ::  constant_bottom_heatflux = .TRUE.                !< heat flux at domain bottom constant?
     LOGICAL ::  constant_top_heatflux = .TRUE.                   !< heat flux at domain top constant?
     LOGICAL ::  constant_top_momentumflux = .FALSE.              !< momentum flux at domain topconstant?
-    LOGICAL ::  constant_salinityflux = .TRUE.                   !< salinity flux
     LOGICAL ::  constant_top_salinityflux = .TRUE.               !< salinity flux at ocean domain top?
     LOGICAL ::  constant_bottom_salinityflux = .TRUE.            !< salinity flux at ocean domain bottom?
     LOGICAL ::  constant_top_scalarflux = .TRUE.                 !< passive-scalar flux at domain top constant?

--- a/trunk/SOURCE/modules.f90
+++ b/trunk/SOURCE/modules.f90
@@ -1188,6 +1188,7 @@
     CHARACTER (LEN=20)   ::  reference_state = 'initial_profile'          !< namelist parameter
     CHARACTER (LEN=20)   ::  timestep_scheme = 'runge-kutta-3'            !< namelist parameter
     CHARACTER (LEN=20)   ::  turbulence_closure = 'Moeng_Wyngaard'        !< namelist parameter. Options include 'Moeng_Wyngaard','AMD'
+    CHARACTER (LEN=40)   ::  ice_cover = 'full'                           !< namelist parameter
     CHARACTER (LEN=40)   ::  topography = 'flat'                          !< namelist parameter
     CHARACTER (LEN=64)   ::  host = '????'                                !< hostname on which PALM is running, ENVPAR namelist parameter provided by mrun
     CHARACTER (LEN=80)   ::  log_message                                  !< user-defined message for debugging (sse data_log.f90)

--- a/trunk/SOURCE/netcdf_data_input_mod.f90
+++ b/trunk/SOURCE/netcdf_data_input_mod.f90
@@ -504,7 +504,8 @@
 !-- Define input variables for soil_type
     TYPE(soil_in)  ::  soil_type_f           !< input variable for soil type
 
-    TYPE(fracs) ::  surface_fraction_f       !< input variable for surface fraction
+    TYPE(fracs) ::  surface_fraction_f       !< input variable for bottom surface fraction
+    TYPE(fracs) ::  top_surface_fraction_f   !< input variable for top surface fraction
 
     TYPE(pars)  ::  albedo_pars_f              !< input variable for albedo parameters
     TYPE(pars)  ::  building_pars_f            !< input variable for building parameters
@@ -607,8 +608,8 @@
            pavement_pars_f, pavement_subsurface_pars_f, pavement_type_f,       &
            root_area_density_lad_f, root_area_density_lsm_f, soil_pars_f,      &
            soil_type_f, street_crossing_f, street_type_f, surface_fraction_f,  &
-           terrain_height_f, vegetation_pars_f, vegetation_type_f,             &
-           water_pars_f, water_type_f
+           terrain_height_f, top_surface_fraction_f, vegetation_pars_f,        &
+           vegetation_type_f, water_pars_f, water_type_f
 
 !
 !-- Public subroutines
@@ -994,6 +995,35 @@
                              0, surface_fraction_f%nf-1 )
        ELSE
           surface_fraction_f%from_file = .FALSE.
+       ENDIF
+!
+!--    Read relative top surface fractions of ice. Where not ice, assumed to be atmosphere
+       IF ( check_existence( var_names, 'top_surface_fraction' ) )  THEN
+          top_surface_fraction_f%from_file = .TRUE.
+          CALL get_attribute( id_surf, char_fill,                              &
+                              top_surface_fraction_f%fill,                     &
+                              .FALSE., 'top_surface_fraction' )
+!
+!--       Inquire number of surface fractions
+          CALL get_dimension_length( id_surf,                                  &
+                                     top_surface_fraction_f%nf,                &
+                                     'ntop_surface_fraction' )
+!
+!--       Allocate dimension array and input array for surface fractions
+          ALLOCATE( top_surface_fraction_f%nfracs(0:top_surface_fraction_f%nf-1) )
+          ALLOCATE( top_surface_fraction_f%frac(0:top_surface_fraction_f%nf-1, &
+                                            nys:nyn,nxl:nxr) )
+!
+!--       Get dimension of surface fractions
+          CALL get_variable( id_surf, 'ntop_surface_fraction',                &
+                             top_surface_fraction_f%nfracs )
+!
+!--       Read surface fractions
+          CALL get_variable( id_surf, 'top_surface_fraction',                  &
+                             top_surface_fraction_f%frac, nxl, nxr, nys, nyn,  &
+                             0, top_surface_fraction_f%nf-1 )
+       ELSE
+          top_surface_fraction_f%from_file = .FALSE.
        ENDIF
 !
 !--    Read building parameters and related information
@@ -1398,6 +1428,22 @@
           DEALLOCATE( var_dum_real_3d )
        ENDIF
 
+       IF ( top_surface_fraction_f%from_file )  THEN
+          ALLOCATE( var_dum_real_3d(0:top_surface_fraction_f%nf-1,nys:nyn,nxl:nxr) )
+          var_dum_real_3d = top_surface_fraction_f%frac
+          DEALLOCATE( top_surface_fraction_f%frac )
+          ALLOCATE( top_surface_fraction_f%frac(0:top_surface_fraction_f%nf-1,   &
+                                                nysg:nyng,nxlg:nxrg) )
+          top_surface_fraction_f%frac = top_surface_fraction_f%fill
+
+          DO  k = 0, top_surface_fraction_f%nf-1
+             var_exchange_real(nys:nyn,nxl:nxr) = var_dum_real_3d(k,nys:nyn,nxl:nxr)
+             CALL exchange_horiz_2d( var_exchange_real, nbgp )
+             top_surface_fraction_f%frac(k,:,:) = var_exchange_real(:,:)
+          ENDDO
+          DEALLOCATE( var_dum_real_3d )
+       ENDIF
+
        IF ( building_pars_f%from_file )  THEN
           ALLOCATE( var_dum_real_3d(0:building_pars_f%np-1,nys:nyn,nxl:nxr) )
           var_dum_real_3d = building_pars_f%pars_xy
@@ -1582,6 +1628,8 @@
                 water_type_f%var(-1,:) = water_type_f%var(0,:)
              IF ( surface_fraction_f%from_file )                               &
                 surface_fraction_f%frac(:,-1,:) = surface_fraction_f%frac(:,0,:)
+             IF ( top_surface_fraction_f%from_file )                           &
+                top_surface_fraction_f%frac(:,-1,:) = top_surface_fraction_f%frac(:,0,:)
              IF ( building_pars_f%from_file )                                  &
                 building_pars_f%pars_xy(:,-1,:) = building_pars_f%pars_xy(:,0,:)
              IF ( albedo_pars_f%from_file )                                    &
@@ -1627,6 +1675,9 @@
              IF ( surface_fraction_f%from_file )                               &
                 surface_fraction_f%frac(:,ny+1,:) =                            &
                                              surface_fraction_f%frac(:,ny,:)
+             IF ( top_surface_fraction_f%from_file )                           &
+                top_surface_fraction_f%frac(:,ny+1,:) =                        &
+                                             top_surface_fraction_f%frac(:,ny,:)
              IF ( building_pars_f%from_file )                                  &
                 building_pars_f%pars_xy(:,ny+1,:) =                            &
                                              building_pars_f%pars_xy(:,ny,:)
@@ -1676,6 +1727,8 @@
                 water_type_f%var(:,-1) = water_type_f%var(:,0)
              IF ( surface_fraction_f%from_file )                               &
                 surface_fraction_f%frac(:,:,-1) = surface_fraction_f%frac(:,:,0)
+             IF ( top_surface_fraction_f%from_file )                           &
+                top_surface_fraction_f%frac(:,:,-1) = top_surface_fraction_f%frac(:,:,0)
              IF ( building_pars_f%from_file )                                  &
                 building_pars_f%pars_xy(:,:,-1) = building_pars_f%pars_xy(:,:,0)
              IF ( albedo_pars_f%from_file )                                    &
@@ -1721,6 +1774,9 @@
              IF ( surface_fraction_f%from_file )                               &
                 surface_fraction_f%frac(:,:,nx+1) =                            &
                                              surface_fraction_f%frac(:,:,nx)
+             IF ( top_surface_fraction_f%from_file )                           &
+                top_surface_fraction_f%frac(:,:,nx+1) =                        &
+                                             top_surface_fraction_f%frac(:,:,nx)
              IF ( building_pars_f%from_file )                                  &
                 building_pars_f%pars_xy(:,:,nx+1) =                            &
                                              building_pars_f%pars_xy(:,:,nx)
@@ -3088,6 +3144,22 @@
                                   2, 2, myid, 6, 0 )
                 ENDIF
              ENDIF
+             IF ( n_surf > 1 )  THEN
+                IF ( .NOT. top_surface_fraction_f%from_file )  THEN
+                   message_string = 'If more than one top_surface type is ' //  &
+                                 'given at a location, top_surface_fraction ' //&
+                                 'must be provided.'
+                   CALL message( 'netcdf_data_input_mod', 'NDI027',             &
+                                  2, 2, myid, 6, 0 )
+                ELSEIF ( ANY ( top_surface_fraction_f%frac(:,j,i) ==            &
+                               top_surface_fraction_f%fill ) )  THEN
+                   message_string = 'If more than one top surface type is ' //  &
+                                 'given at a location, top_surface_fraction ' //&
+                                 'must be provided.'
+                   CALL message( 'netcdf_data_input_mod', 'NDI027',             &
+                                  2, 2, myid, 6, 0 )
+                ENDIF
+             ENDIF
 !
 !--          Check for further mismatches. e.g. relative fractions exceed 1 or
 !--          vegetation_type is set but surface vegetation fraction is zero, 
@@ -3151,6 +3223,15 @@
                              ' ), but surface fraction is not 0 for the ' //   &
                              'given type.'
                    CALL message( 'netcdf_data_input_mod', 'NDI030',            &
+                                  2, 2, myid, 6, 0 )
+                ENDIF
+             ENDIF
+             IF ( top_surface_fraction_f%from_file )  THEN
+!
+!--             Sum of relative fractions must not exceed 1.
+                IF ( SUM ( top_surface_fraction_f%frac(:,j,i) ) > 1.0_wp )  THEN
+                   message_string = 'top_surface_fraction must not exceed 1'
+                   CALL message( 'netcdf_data_input_mod', 'NDI028',            &
                                   2, 2, myid, 6, 0 )
                 ENDIF
              ENDIF

--- a/trunk/SOURCE/netcdf_data_input_mod.f90
+++ b/trunk/SOURCE/netcdf_data_input_mod.f90
@@ -864,7 +864,7 @@
 !--    variables are read from file.
        IF ( ALLOCATED( var_names ) )  DEALLOCATE( var_names )
 !
-!--    Skip the following if no land-surface or urban-surface module are
+!--    Skip the following if no land-surface or urban-surface or ice-surface module are
 !--    applied. This case, no one of the following variables is used anyway.
        IF (  .NOT. land_surface  .OR.  .NOT. urban_surface )  RETURN
 !

--- a/trunk/SOURCE/netcdf_data_input_mod.f90
+++ b/trunk/SOURCE/netcdf_data_input_mod.f90
@@ -264,6 +264,7 @@
        INTEGER(iwp) ::  nzu       !< number of vertical levels on scalar grid in dynamic input file
        INTEGER(iwp) ::  nzw       !< number of vertical levels on w grid in dynamic input file
 
+       LOGICAL ::  from_file_icecover  = .FALSE. !< flag indicating whether ice cover is already initialized from file
        LOGICAL ::  from_file_msoil  = .FALSE. !< flag indicating whether soil moisture is already initialized from file
        LOGICAL ::  from_file_pt     = .FALSE. !< flag indicating whether pt is already initialized from file
        LOGICAL ::  from_file_q      = .FALSE. !< flag indicating whether q is already initialized from file
@@ -274,6 +275,7 @@
        LOGICAL ::  from_file_vg     = .FALSE. !< flag indicating whether ug is already initialized from file
        LOGICAL ::  from_file_w      = .FALSE. !< flag indicating whether w is already initialized from file
 
+       REAL(wp) ::  fill_icecover    !< fill value for soil moisture
        REAL(wp) ::  fill_msoil       !< fill value for soil moisture
        REAL(wp) ::  fill_pt          !< fill value for pt
        REAL(wp) ::  fill_q           !< fill value for q
@@ -288,6 +290,7 @@
        REAL(wp) ::  origin_z         !< reference height of input data
        REAL(wp) ::  rotation_angle   !< rotation angle of input data
 
+       REAL(wp), DIMENSION(:), ALLOCATABLE ::  icecover_init!< initial horizontal distribution of ice cover
        REAL(wp), DIMENSION(:), ALLOCATABLE ::  msoil_init   !< initial vertical profile of soil moisture
        REAL(wp), DIMENSION(:), ALLOCATABLE ::  pt_init      !< initial vertical profile of pt
        REAL(wp), DIMENSION(:), ALLOCATABLE ::  q_init       !< initial vertical profile of q

--- a/trunk/SOURCE/parin.f90
+++ b/trunk/SOURCE/parin.f90
@@ -526,7 +526,7 @@
              dz_stretch_level_end, d_stk,                                      &
              end_time_1d, ensemble_member_nr, e_init,                          &
              e_min, fft_method, flux_input_mode, flux_output_mode, forcing,    &
-             galilei_transformation, humidity,                                 &
+             galilei_transformation, humidity, ice_cover,                      &
              inflow_damping_height, inflow_damping_width,                      &
              inflow_disturbance_begin, inflow_disturbance_end,                 &
              initialize_to_geostrophic, initializing_actions, km_constant,     &
@@ -611,7 +611,7 @@
              dz_stretch_level_start, dz_stretch_level_end, d_stk,              &
              end_time_1d, ensemble_member_nr, e_init,                          &
              e_min, fft_method, flux_input_mode, flux_output_mode, forcing,    &
-             galilei_transformation, gamma_mcphee, humidity,                   &
+             galilei_transformation, gamma_mcphee, humidity, ice_cover,        &
              ij_av_width_mcphee, inflow_damping_height, inflow_damping_width,  &
              inflow_disturbance_begin, inflow_disturbance_end,                 &
              initialize_to_geostrophic, initializing_actions, km_constant,     &

--- a/trunk/SOURCE/read_restart_data_mod.f90
+++ b/trunk/SOURCE/read_restart_data_mod.f90
@@ -441,6 +441,8 @@
                 READ ( 13 )  hom_sum
              CASE ( 'humidity' )
                 READ ( 13 )  humidity
+             CASE ( 'ice_cover' )
+                READ ( 13 )  ice_cover
              CASE ( 'inflow_damping_factor' )
                 IF ( .NOT. ALLOCATED( inflow_damping_factor ) )  THEN
                    ALLOCATE( inflow_damping_factor(0:nz+1) )

--- a/trunk/SOURCE/surface_layer_fluxes_mod.f90
+++ b/trunk/SOURCE/surface_layer_fluxes_mod.f90
@@ -2339,12 +2339,12 @@
 !
 !--       Compute the vertical kinematic heat flux, salt flux, and melt rate 
 !--       according to the 3 equation parameterization (Asay-Davis et al. 2016)
-          IF ( TRIM(most_method) == 'mcphee' .AND. downward ) THEN
+          IF ( TRIM(most_method) == 'mcphee' .AND. downward) THEN
              
              !$OMP PARALLEL DO PRIVATE( i, j, k, s_factor )
              DO  m = 1, surf%ns  
-   
-                i = surf%i(m)            
+                ! TODO check whether m cell is ice covered
+                i = surf%i(m)
                 j = surf%j(m)
                 k = surf%k(m)
                 

--- a/trunk/SOURCE/surface_mod.f90
+++ b/trunk/SOURCE/surface_mod.f90
@@ -2238,12 +2238,6 @@
                       surf%shf(num_h) = 0.0_wp
                       surf%melt(num_h) = 0.0_wp
                       surf%sasws(num_h) = 0.0_wp
-                      IF ( TRIM(ice_cover) == 'full' ) THEN
-                         surf%ice_fraction(num_h) = 1.0_wp
-                      ELSEIF ( TRIM(ice_cover) == 'read_from_file' ) THEN
-                         !TODO assign from netcdf
-                         surf%ice_fraction(num_h) = 0.0_wp
-                      ENDIF
                       IF ( constant_top_heatflux )                                &
                          surf%shf(num_h) = (1.0_wp - surf%ice_fraction(num_h)) *  &
                                            top_heatflux *                         &
@@ -2252,7 +2246,7 @@
                          surf%sasws(num_h) = (1.0_wp - surf%ice_fraction(num_h)) * &
                                              top_salinityflux *                    &
                                              salinityflux_input_conversion(nzt+1)
-
+                      call initialize_ice_surface(surf, num_h, ice_cover)
                    ENDIF
                    surf%pt_surface(num_h) = pt_surface
                    surf%sa_surface(num_h) = sa_surface

--- a/trunk/SOURCE/surface_mod.f90
+++ b/trunk/SOURCE/surface_mod.f90
@@ -302,6 +302,7 @@
        LOGICAL, DIMENSION(:), ALLOCATABLE  ::  pavement_surface    !< flag parameter for pavements
        LOGICAL, DIMENSION(:), ALLOCATABLE  ::  water_surface       !< flag parameter for water surfaces
        LOGICAL, DIMENSION(:), ALLOCATABLE  ::  vegetation_surface  !< flag parameter for natural land surfaces
+       LOGICAL, DIMENSION(:), ALLOCATABLE  ::  ice_surface         !< flag parameter indicating an ice surface element
 
        REAL(wp), DIMENSION(:,:), ALLOCATABLE ::  albedo            !< broadband albedo for each surface fraction (LSM: vegetation, water, pavement; USM: wall, green, window)
        REAL(wp), DIMENSION(:,:), ALLOCATABLE ::  emissivity        !< emissivity of the surface, for each fraction  (LSM: vegetation, water, pavement; USM: wall, green, window)
@@ -1238,6 +1239,7 @@
        IF ( most_method == 'mcphee' ) THEN
           ALLOCATE ( surfaces%gamma_T(1:surfaces%ns) )
           ALLOCATE ( surfaces%gamma_S(1:surfaces%ns) )
+          ALLOCATE ( surfaces%ice_surface(1:surfaces%ns) )
           ALLOCATE ( surfaces%melt(1:surfaces%ns) )
        ENDIF
 

--- a/trunk/SOURCE/surface_mod.f90
+++ b/trunk/SOURCE/surface_mod.f90
@@ -2246,7 +2246,6 @@
                          surf%sasws(num_h) = (1.0_wp - surf%ice_fraction(num_h)) * &
                                              top_salinityflux *                    &
                                              salinityflux_input_conversion(nzt+1)
-                      call initialize_ice_surface(surf, num_h, ice_cover)
                    ENDIF
                    surf%pt_surface(num_h) = pt_surface
                    surf%sa_surface(num_h) = sa_surface

--- a/trunk/SOURCE/write_restart_data_mod.f90
+++ b/trunk/SOURCE/write_restart_data_mod.f90
@@ -437,6 +437,9 @@
        CALL wrd_write_string( 'humidity' ) 
        WRITE ( 14 )  humidity
 
+       CALL wrd_write_string( 'ice_cover' ) 
+       WRITE ( 14 )  ice_cover
+
        IF ( ALLOCATED( inflow_damping_factor ) )  THEN
           CALL wrd_write_string( 'inflow_damping_factor' ) 
           WRITE ( 14 )  inflow_damping_factor


### PR DESCRIPTION
When `most_method = 'mcphee'` it is assumed that the top surface is ice.

Now, we add the option to have either `ice_cover = 'full'` designating ice cover across the entire top surface (which is the default value of `ice_cover`) or read in values for ice fraction from a netcdf file when `ice_cover = 'read_from_file'`. The ice fraction ranges from 1 (full ice cover) to 0 (no ice cover) and can vary across the domain.

This option makes use of the existing `PIDS_STATIC` method of inputting surface fractions as well as other surface properties. A script is provided for generating the `PIDS_STATIC` netcdf file. When the model is run, `PIDS_STATIC` must be present in the working directory for the `ice_cover = 'read_from_file'` option to work. 

This option may be used in combination with atmospheric forcing. The `top_*flux` namelist options describe the atmospheric fluxes at the top of the domain, which is applied in proportion to (1 - `ice_fraction`) along with the McPhee parameterized scalar and momentum fluxes.